### PR TITLE
Fix build with XCode 12 and fix Curl being required to build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ set(SRC_FILES
   simplerng.c f77_wrap1.c f77_wrap2.c f77_wrap3.c f77_wrap4.c
 )
 
-find_package(CURL REQUIRED)
+find_package(CURL)
 
 add_library(cfitsio ${LIB_TYPE} ${H_FILES} ${SRC_FILES})
 add_library(cfitsio::cfitsio ALIAS cfitsio)
@@ -84,8 +84,6 @@ target_include_directories(cfitsio
   PUBLIC
     $<INSTALL_INTERFACE:include/>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-  PRIVATE
-    $<BUILD_INTERFACE:${CURL_INCLUDE_DIRS}>
 )
 
 target_link_libraries(cfitsio
@@ -93,10 +91,19 @@ target_link_libraries(cfitsio
     ${M_LIB}
   PRIVATE
     ${PTHREADS_LIBRARY}
-    ${CURL_LIBRARIES}
 )
 
 if(CURL_FOUND)
+  target_include_directories(cfitsio
+    PRIVATE
+      $<BUILD_INTERFACE:${CURL_INCLUDE_DIRS}>
+  )
+
+  target_link_libraries(cfitsio
+    PRIVATE
+      ${CURL_LIBRARIES}
+  )
+
   target_compile_definitions(cfitsio
     PRIVATE
       unix CFITSIO_HAVE_CURL HAVE_NET_SERVICES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,11 @@ else()
   find_library(M_LIB m)
 endif()
 
+# Let MacOS include <unistd.h>
+if(APPLE)
+  add_definitions(-DHAVE_UNISTD_H)
+endif()
+
 set(SRC_FILES
   buffers.c cfileio.c checksum.c drvrfile.c drvrmem.c drvrnet.c drvrsmem.c
   drvrgsiftp.c editcol.c edithdu.c eval_l.c eval_y.c eval_f.c fitscore.c


### PR DESCRIPTION
This PR fixes two unrelated issues:

1) After an update to Apple's clang compiler, a missing header include to get access to the `getcwd` function. which was previously a warning, has now turned into an error. To fix this, the pre-processor variable `HAVE_UNISTD_H` must be defined. I guess this is normally done by the auto-tools configure script, but this is missing currently in the CMake scripts. I added the logic to do that.

2) Recent updates to this repository's CMake script have added Curl as a dependency, but made it mandatory. The code however supports Curl being missing, so I have made the necessary change to the CMake script to let cfitsio build even if Curl is missing.