### PR TITLE
Add basic TPV legacy support for IRAF

### DIFF
--- a/wcsutil.c
+++ b/wcsutil.c
@@ -81,7 +81,8 @@ int ffwldp(double xpix, double ypix, double xref, double yref,
       dect = dec0 + m;
 
     } else if (*cptr == 'T') {  /* -TAN */
-      if (*(cptr + 1) != 'A' ||  *(cptr + 2) != 'N') {
+      if ( !(*(cptr + 1) == 'A' && *(cptr + 2) == 'N') &&
+           !(*(cptr + 1) == 'P' && *(cptr + 2) == 'V') ) {
          return(*status = 504);
       }
       x = cos0*cos(ra0) - l*sin(ra0) - m*cos(ra0)*sin0;


### PR DESCRIPTION
Since IRAF implemented FITS support using cfitsio, it uses a patched version that adds [TPV](https://fits.gsfc.nasa.gov/registry/tpvwcs/tpv.html) support. This support is very basic and just adds TPV as an alias to TAN, ignoring any PV_*i*_*j* values; obviously just to support reading older files instead of returning an error.

This change survived [in the community version of IRAF](https://github.com/iraf-community/iraf/blob/5c0a2a736e4a7104cc254e71c06e3e65fc6df65b/vendor/trim_cfitsio.sh#L17-L34), and also [in the independent IRAF fitsutil package maintained by NOIRLAB](https://github.com/noirlab-iraf/fitsutil/commit/c4d9c72116355eb87b2d2b27fe9440c115af27ea).

To keep compatibility here, it would be nice to have this in the main cfitsio package, allowing to link IRAF to the plain cfitsio library instead of maintaining a changed copy.

Cc @mjfitzpatrick @noirlab-iraf @noirlab-iraf-admin who may add more information about the use of TPV within IRAF.