### PR TITLE
BUG make string column nulls compliant with the FITS standard

### DIFF
--- a/putcols.c
+++ b/putcols.c
@@ -155,9 +155,13 @@ int ffpcls( fitsfile *fptr,  /* I - FITS file pointer                       */
               break;
          }
 
-         for (;jj < twidth; jj++)    /* fill field with blanks, if needed */
+         for (;jj < twidth; jj++)    /* fill field with blanks/nulls, if needed */
          {
-           *buffer = ' ';
+           if (snull[0] == ASCII_NULL_UNDEFINED) {
+             *buffer = ' ';
+           } else {
+             *buffer = '\0';
+           }
            buffer++;
          }
 


### PR DESCRIPTION
The standard states


> Character. If the value of the TFORMn keyword specifies Data Type ’A’, Field n shall contain a character string of zero-or more members, composed of the restricted set of ASCII-text characters. This character string may be terminated before the length specified by the repeat count by an ASCII NULL (hexadecimal code 00). Characters after the first ASCII NULL are not defined. A string with the number of characters specified by the repeat count is not NULL terminated. Null strings are defined by the presence of an ASCII NULL as the first character.


So strings are not NULL terminated, but if they end before the fixed width ends, they are filled with NULLs. Currently cfitsio fills with spaces. The patch here leaves spaces working for ascii tables but uses nulls for binary tables.