### PR TITLE
Fix build with recent latex versions

### DIFF
--- a/docs/cfitsio.tex
+++ b/docs/cfitsio.tex
@@ -3404,7 +3404,7 @@ See section \ref{character-strings}
 
 For complex and double complex data types, \verb+nelements+ is the number
 of numerical pairs; the number of floats or doubles stored by
-\+array+ must be \verb+2*nelements+.
+\verb+array+ must be \verb+2*nelements+.
 
 For the logical data (TLOGICAL), the C storage type is a \verb+char+
 single-byte character.  A FITS value of `\verb+T+'rue reads as 1 and
@@ -9271,7 +9271,7 @@ usage. Also, the integer to real casts values to double precision:
       #EXPOSURE = gtioverlap('gtifile',#TSTART,#TSTOP)
 \end{verbatim}
 
-    The \verb+#EXPOSURE+ syntax with a leading \+#+ ensures that the 
+    The \verb+#EXPOSURE+ syntax with a leading \verb+#+ ensures that the
     requested values are treated as keywords.  Otherwise, a column
     named EXPOSURE will be created with the (constant) exposure value
     in each entry.  

--- a/docs/fitsio.tex
+++ b/docs/fitsio.tex
@@ -6274,7 +6274,7 @@ usage. Also, the integer to real casts values to double precision:
            0b01001 binary integer
 \end{verbatim}
     Note that integer constants are only allowed to be 32-bit, i.e.
-    between -2^(31) and +2^(31).  Integer constants may be used in any
+    between -2\^(31) and +2\^(31).  Integer constants may be used in any
     arithmetic expression where an integer would be appropriate.  Thus,
     they are distinct from bitmasks (which may be of arbitrary length,
     allow the "wildcard" bit, and may only be used in logical
@@ -6619,7 +6619,7 @@ usage. Also, the integer to real casts values to double precision:
       #EXPOSURE = gtioverlap('gtifile',#TSTART,#TSTOP)
 \end{verbatim}
 
-    The \verb+#EXPOSURE+ syntax with a leading \+#+ ensures that the 
+    The \verb+#EXPOSURE+ syntax with a leading \verb+#+ ensures that the
     requested values are treated as keywords.  Otherwise, a column
     named EXPOSURE will be created with the (constant) exposure value
     in each entry.  


### PR DESCRIPTION
Some characters needs to be properly escaped to avoid triggering errors with recent latex versions. For instance:

  ! Undefined control sequence.
  l.3407 \+
           array+ must be \verb+2*nelements+.