### PR TITLE
Add support for hurd

### DIFF
--- a/fitsio.h
+++ b/fitsio.h
@@ -72,7 +72,7 @@ SERVICES PROVIDED HEREUNDER."
 #  define _MIPS_SZLONG 64
 #endif
 
-#if defined(linux) || defined(__APPLE__) || defined(__sgi)
+#if defined(__GLIBC__) || defined(__APPLE__) || defined(__sgi)
 #  include <sys/types.h>  /* apparently needed on debian linux systems */
 #endif                    /* to define off_t                           */
 
@@ -86,10 +86,10 @@ SERVICES PROVIDED HEREUNDER."
 /* on whether _LARGEFILE_SOURCE is defined in sys/feature_tests.h  */
 /* (at least on Solaris platforms using cc)  */
 
-/*  Debian systems require: "(defined(linux) && defined(__off_t_defined))" */
+/*  Debian systems require: "(defined(__GLIBC__) && defined(__off_t_defined))" */
 /*  the mingw-w64 compiler requires: "(defined(__MINGW32__) && defined(_OFF_T_DEFINED))" */
 #if defined(_OFF_T) \
-    || (defined(linux) && defined(__off_t_defined)) \
+    || (defined(__GLIBC__) && defined(__off_t_defined)) \
     || (defined(__MINGW32__) && defined(_OFF_T_DEFINED)) \
     || defined(_MIPS_SZLONG) || defined(__APPLE__) || defined(_AIX)
 #    define OFF_T off_t


### PR DESCRIPTION
This replaces defined(linux) by define(__GLIBC__) as the way off_t is defined is specific to the GNU libc and not to the linux kernel.

This fixes the build on GNU/Hurd, and probably improves the support for other libc like MUSL.