### PR TITLE
Update getcols.c

### DIFF
--- a/getcols.c
+++ b/getcols.c
@@ -567,7 +567,7 @@ int ffgcls( fitsfile *fptr,   /* I - FITS file pointer                       */
       {
            if (tcode == TBIT)
            {
-               byteval = (char) darray[ii];
+               byteval = (unsigned char) darray[ii];
 
                for (ll=0; ll < 8; ll++)
                {


### PR DESCRIPTION
Bug fix that was causing invalid bit column output with clang compilers at O2 optimization level.