### PR TITLE
Link fpack and funpack with -lm

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -149,8 +149,10 @@ fitsverify_SOURCES = utilities/ftverify.c utilities/fvrf_data.c \
 		     utilities/fvrf_key.c utilities/fvrf_misc.c
 
 fpack_SOURCES = utilities/fpack.c utilities/fpackutil.c
+fpack_LDADD = -lm ${LDADD}
 
 funpack_SOURCES = utilities/funpack.c utilities/fpackutil.c
+funpack_LDADD = -lm ${LDADD}
 
 imcopy_SOURCES = utilities/imcopy.c
 


### PR DESCRIPTION
fpack and funpack use math functions, so they need to be linked with the math library using -lm. It works on some systems due to libcfitsio.so being linked with libm.so.6. This does not work on systems where libtool is configured with 'link_all_deplibs=no', and causes the following linking error:

/bin/bash ./libtool  --tag=CC   --mode=link gcc  -g -O2 -Dg77Fortran   -o fpack utilities/fpack.o utilities/fpackutil.o libcfitsio.la -lpthread -lz -lbz2  -lpthread -lz -lbz2
libtool: link: gcc -g -O2 -Dg77Fortran -o .libs/fpack utilities/fpack.o utilities/fpackutil.o  ./.libs/libcfitsio.so -lpthread -lz -lbz2 -Wl,-rpath -Wl,/home/aurel32/git/cfitsio/lib
/usr/bin/ld: utilities/fpackutil.o: undefined reference to symbol 'log10@@GLIBC_2.2.5'
/usr/bin/ld: /lib/x86_64-linux-gnu/libm.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make: *** [Makefile:841: fpack] Error 1