### PR TITLE
Add GitHub workflow to perform CodeQL code analysis on project

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,72 @@
+# See https://codeql.github.com/ for details on CodeQL.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "develop", "main" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "develop", "main" ]
+  schedule:
+    - cron: '30 10 * * 2'
+
+jobs:
+  analyze:
+    name: Analyze
+    # Runner size impacts CodeQL analysis time. To learn more, please see:
+    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/using-larger-runners
+    # Consider using larger runners for possible analysis time improvements.
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'c-cpp' ]
+        # CodeQL supports [ 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift' ]
+        # Use only 'java-kotlin' to analyze code written in Java, Kotlin or both
+        # Use only 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+    - name: Install dependencies
+      run: sudo apt-get -o Acquire::Retries=3 update && sudo apt-get -o Acquire::Retries=3 -y install build-essential zlib1g-dev libffi-dev make cmake apt-file software-properties-common libssl-dev build-essential autotools-dev automake autoconf libtool pkgconf gcc gfortran g++
+
+    - name: Build CFITSIO
+      run: |
+          autoreconf -f -i
+          ./configure
+          CFLAGS="-Wp,-D_GLIBCXX_ASSERTIONS"
+          export CFLAGS
+          CXXFLAGS="-Wp,-D_GLIBCXX_ASSERTIONS"
+          export CXXFLAGS
+          gcc --version
+          make
+          make install
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"


### PR DESCRIPTION
See https://codeql.github.com/ for details on CodeQL.

To enable, after merging this PR, a project administrator would need to go to https://github.com/HEASARC/cfitsio/security and enable "Code scanning alerts".

You can review the current (at the time of this writing) CodeQL alerts in the run I performed in my personal cfitsio fork at https://github.com/esabol/cfitsio/security/code-scanning