### PR TITLE
Address some CodeQL scanning alerts

### DIFF
--- a/eval_y.c
+++ b/eval_y.c
@@ -3899,10 +3899,10 @@ static int New_GTI( ParseData *lParse, funcOp Op, char *fname, int Node1, int No
 {
    fitsfile *fptr;
    Node *this, *that0, *that1, *that2;
-   int  type,i,n, startCol, stopCol, Node0;
+   int  type, n, startCol, stopCol, Node0;
    int  hdutype, hdunum, evthdu, samefile, extvers, movetotype, tstat;
    char extname[100];
-   long nrows;
+   long nrows, i;
    double timeZeroI[2], timeZeroF[2], dt, timeSpan;
    char xcol[20], xexpr[20];
    YYSTYPE colVal;

--- a/fits_hdecompress.c
+++ b/fits_hdecompress.c
@@ -1308,7 +1308,7 @@ unsigned char *scratch;
 	 */
 	nqx2=(nqx+1)/2;
 	nqy2=(nqy+1)/2;
-	scratch = (unsigned char *) malloc(nqx2*nqy2);
+	scratch = (unsigned char *) malloc((size_t)nqx2*nqy2);
 	if (scratch == (unsigned char *) NULL) {
 		ffpmsg("qtree_decode: insufficient memory");
 		return(DATA_DECOMPRESSION_ERR);
@@ -1398,7 +1398,7 @@ unsigned char *scratch;
 	 */
 	nqx2=(nqx+1)/2;
 	nqy2=(nqy+1)/2;
-	scratch = (unsigned char *) malloc(nqx2*nqy2);
+	scratch = (unsigned char *) malloc((size_t)nqx2*nqy2);
 	if (scratch == (unsigned char *) NULL) {
 		ffpmsg("qtree_decode64: insufficient memory");
 		return(DATA_DECOMPRESSION_ERR);

--- a/imcompress.c
+++ b/imcompress.c
@@ -6860,7 +6860,7 @@ int imcomp_decompress_tile (fitsfile *infptr,
      if ((infptr->Fptr)->znaxis[0]   != (infptr->Fptr)->tilesize[0] ||
         (infptr->Fptr)->tilesize[1] != 1 )
      {
-      tilesize = pixlen * tilelen;
+      tilesize = (long)pixlen * tilelen;
 
       /* check that tile size/type has not changed */
       if (tilesize != (infptr->Fptr)->tiledatasize[tilecol] ||


### PR DESCRIPTION
This PR addresses some CodeQL scanning alerts for "multiplication result converted to larger type" and "wrong type of argument to formatting function."