### PR TITLE
cfitsio.pc.cmake: Use GNUInstallDirs to configure library and include paths in template

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ INCLUDE(CheckLibraryExists)
 INCLUDE(CheckFunctionExists)
 INCLUDE(CheckSymbolExists)
 INCLUDE(CheckCSourceCompiles)
+INCLUDE(GNUInstallDirs)
 
 #==============================================================================
 # Build options:
@@ -291,14 +292,14 @@ set_property(TARGET cfitsio APPEND PROPERTY
 )
 
 install(TARGETS cfitsio EXPORT cfitsioTargets
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
-  RUNTIME DESTINATION bin
-  INCLUDES DESTINATION include
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 install(FILES ${H_FILES} "${CMAKE_CURRENT_BINARY_DIR}/cfitsio_export.h"
-        DESTINATION include COMPONENT Devel)
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT Devel)
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
@@ -316,7 +317,7 @@ configure_file(cmake/cfitsioConfig.cmake
   COPYONLY
 )
 
-set(ConfigPackageLocation lib/cmake/cfitsio)
+set(ConfigPackageLocation ${CMAKE_INSTALL_LIBDIR}/cmake/cfitsio)
 install(EXPORT cfitsioTargets
   FILE
     cfitsioTargets.cmake
@@ -337,7 +338,7 @@ install(
 
 # cfitsio.pc:
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cfitsio.pc.cmake ${CMAKE_CURRENT_BINARY_DIR}/cfitsio.pc @ONLY)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cfitsio.pc DESTINATION lib/pkgconfig)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cfitsio.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
 #==============================================================================
 # Test programs:
@@ -399,9 +400,9 @@ IF (UTILS)
       set_target_properties(fpack funpack PROPERTIES LINK_FLAGS "setargv.obj")
     endif()
 
-    install(TARGETS fpack funpack fitscopy fitsverify imcopy speed RUNTIME DESTINATION bin)
+    install(TARGETS fpack funpack fitscopy fitsverify imcopy speed RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
     IF(HAVE_SHMEM_SERVICES)
-      install(TARGETS smem RUNTIME DESTINATION bin)
+      install(TARGETS smem RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
     ENDIF()
 
 ENDIF(UTILS)

--- a/cfitsio.pc.cmake
+++ b/cfitsio.pc.cmake
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
-includedir=${prefix}/include
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: cfitsio
 Description: FITS File Subroutine Library


### PR DESCRIPTION
Hi,

The pkg-config template should track the paths where CMake installs libraries and headers. I believe doing so may help prevent issues on systems where the default is `lib64`, and in cases when `/lib` might be a symbolic link to `/lib32` on a multiarch distro.

Including `GNUInstallDirs` allows the user to remap directory names within the prefix if they need to:

```
$ cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/tmp/cfitsio -DCMAKE_INSTALL_LIBDIR=lib123 -CMAKE_INSTALL_INCLUDEDIR=headers

$ make install
# ...
Install the project...
-- Install configuration: "Release"
-- Installing: /tmp/cfitsio/lib123/libcfitsio.so.4.6.0
-- Installing: /tmp/cfitsio/lib123/libcfitsio.so.10
-- Installing: /tmp/cfitsio/lib123/libcfitsio.so
-- Installing: /tmp/cfitsio/headers/fitsio.h
-- Installing: /tmp/cfitsio/headers/fitsio2.h
-- Installing: /tmp/cfitsio/headers/longnam.h
-- Installing: /tmp/cfitsio/headers/cfitsio_export.h
-- Installing: /tmp/cfitsio/lib123/cmake/cfitsio/cfitsioTargets.cmake
-- Installing: /tmp/cfitsio/lib123/cmake/cfitsio/cfitsioTargets-release.cmake
-- Installing: /tmp/cfitsio/lib123/cmake/cfitsio/cfitsioConfig.cmake
-- Installing: /tmp/cfitsio/lib123/cmake/cfitsio/cfitsioConfigVersion.cmake
-- Installing: /tmp/cfitsio/lib123/pkgconfig/cfitsio.pc
-- Installing: /tmp/cfitsio/bin/cookbook
-- Set non-toolchain portion of runtime path of "/tmp/cfitsio/bin/cookbook" to ""
-- Installing: /tmp/cfitsio/bin/fpack
-- Set non-toolchain portion of runtime path of "/tmp/cfitsio/bin/fpack" to ""
-- Installing: /tmp/cfitsio/bin/funpack
-- Set non-toolchain portion of runtime path of "/tmp/cfitsio/bin/funpack" to ""
-- Installing: /tmp/cfitsio/bin/fitscopy
-- Set non-toolchain portion of runtime path of "/tmp/cfitsio/bin/fitscopy" to ""
-- Installing: /tmp/cfitsio/bin/fitsverify
-- Set non-toolchain portion of runtime path of "/tmp/cfitsio/bin/fitsverify" to ""
-- Installing: /tmp/cfitsio/bin/imcopy
-- Set non-toolchain portion of runtime path of "/tmp/cfitsio/bin/imcopy" to ""
-- Installing: /tmp/cfitsio/bin/speed
-- Set non-toolchain portion of runtime path of "/tmp/cfitsio/bin/speed" to ""
-- Installing: /tmp/cfitsio/bin/smem
-- Set non-toolchain portion of runtime path of "/tmp/cfitsio/bin/smem" to ""

$ cat /tmp/cfitsio/lib123/pkgconfig/cfitsio.pc
prefix=/tmp/cfitsio
exec_prefix=${prefix}
libdir=${exec_prefix}/lib123
includedir=${prefix}/headers

Name: cfitsio
Description: FITS File Subroutine Library
URL: https://heasarc.gsfc.nasa.gov/fitsio/
Version: 4.6.0
Libs: -L${libdir} -lcfitsio
Libs.private:  -lz -lcurl -lm
Cflags: -I${includedir}

$ PKG_CONFIG_PATH=/tmp/cfitsio/lib123/pkgconfig pkg-config --cflags --libs cfitsio
-I/tmp/cfitsio/headers -L/tmp/cfitsio/lib123 -lcfitsio
```

xref: https://github.com/spacetelescope/hstcal/issues/631#issuecomment-2734572388