### PR TITLE
Remove AC_PROG_RANLIB

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -296,8 +296,6 @@ fi
 ARCHIVE="$AR rv"
 AC_SUBST(ARCHIVE)
 
-AC_PROG_RANLIB
-
 dnl Checks for ANSI stdlib.h.
 AC_CHECK_HEADERS(stdlib.h string.h math.h limits.h ,ANSI_HEADER=yes,ANSI_HEADER=no)dnl
 


### PR DESCRIPTION
This fixes the following warning from `autoreconf -i`:

    glibtoolize: 'AC_PROG_RANLIB' is rendered obsolete by 'LT_INIT'