### PR TITLE
Fix some code warnings and a couple of bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Misc folders
+.vscode/
+build/
+include/
+
 # Prerequisites
 *.d
 
@@ -79,3 +84,8 @@ imcopy
 smem
 speed
 testprog
+iter_a
+iter_b
+iter_c
+iter_image
+iter_var

--- a/cfileio.c
+++ b/cfileio.c
@@ -1740,7 +1740,7 @@ int fits_is_this_a_copy(char *urltype) /* I - type of file */
      iscopy = 1;    /* copied file using ftp protocol */
   else if (!strncmp(urltype, "gsiftp", 6) )
      iscopy = 1;    /* copied file using gsiftp protocol */
-  else if (!strncpy(urltype, "stdin", 5) )
+  else if (!strncmp(urltype, "stdin", 5) )
      iscopy = 1;    /* piped stdin has been copied to memory */
   else
      iscopy = 0;    /* file is not known to be a copy */

--- a/cfileio.c
+++ b/cfileio.c
@@ -420,7 +420,10 @@ int ffeopn(fitsfile **fptr,      /* O - FITS file pointer                   */
 {
     int hdunum, naxis = 0, thdutype, gotext=0;
     char *ext, *textlist;
-    char *saveptr;
+
+    #ifdef _REENTRANT
+        char *saveptr;
+    #endif
   
     if (*status > 0)
         return(*status);

--- a/cfileio.c
+++ b/cfileio.c
@@ -1530,8 +1530,6 @@ int fits_already_open(fitsfile **fptr, /* I/O - FITS file pointer       */
     char oldextspec[FLEN_FILENAME], oldoutfile[FLEN_FILENAME];
     char oldrowfilter[FLEN_FILENAME];
     char oldbinspec[FLEN_FILENAME], oldcolspec[FLEN_FILENAME];
-    char cwd[FLEN_FILENAME];
-    char tmpStr[FLEN_FILENAME];
     char tmpinfile[FLEN_FILENAME]; 
     
     *isopen = 0;
@@ -7394,7 +7392,6 @@ int fits_get_token(char **ptr,
 {
     char *loc, tval[73];
     int slen;
-    double dval;
     
     *token = '\0';
 
@@ -7419,9 +7416,9 @@ int fits_get_token(char **ptr,
 	        /*  The C language does not support a 'D'; replace with 'E' */
 	        if ((loc = strchr(tval, 'D'))) *loc = 'E';
 
-	        dval =  strtod(tval, &loc);
+	       strtod(tval, &loc);
 	    } else {
-	        dval =  strtod(token, &loc);
+	       strtod(token, &loc);
  	    }
 
 	    /* check for read error, or junk following the value */
@@ -7449,7 +7446,6 @@ int fits_get_token2(char **ptr,
 {
     char *loc, tval[73];
     int slen;
-    double dval;
     
     if (*status)
         return(0);
@@ -7481,9 +7477,9 @@ int fits_get_token2(char **ptr,
 	        /*  The C language does not support a 'D'; replace with 'E' */
 	        if ((loc = strchr(tval, 'D'))) *loc = 'E';
 
-	        dval =  strtod(tval, &loc);
+	        strtod(tval, &loc);
 	    } else {
-	        dval =  strtod(*token, &loc);
+	        strtod(*token, &loc);
  	    }
 
 	    /* check for read error, or junk following the value */

--- a/drvrnet.c
+++ b/drvrnet.c
@@ -1447,7 +1447,7 @@ int ftps_open(char *filename, int rwmode, int *handle)
      firstByte = (unsigned char)inmem.memory[0];
      secondByte = (unsigned char)inmem.memory[1];
   }
-  if (firstByte == 0x1f && secondByte == 0x8b || 
+  if ((firstByte == 0x1f && secondByte == 0x8b) || 
         strstr(localFilename,".Z"))
   {
 #ifdef HAVE_FMEMOPEN
@@ -1655,7 +1655,6 @@ int ftps_compress_open(char *filename, int rwmode, int *handle)
   char localFilename[MAXLEN]; /* may have .gz or .Z appended */
   unsigned char firstByte=0,secondByte=0;
   curlmembuf inmem;
-  FILE *compressedInFile=0;
   
   /* don't do r/w files */
   if (rwmode != 0) {
@@ -3758,9 +3757,6 @@ int ftps_checkfile (char *urltype, char *infile, char *outfile1)
 int ftp_checkfile (char *urltype, char *infile, char *outfile1)
 {
   char newinfile[MAXLEN];
-  FILE *ftpfile;
-  FILE *command;
-  int sock;
   int foundfile = 0;
   int status=0;
 

--- a/drvrnet.c
+++ b/drvrnet.c
@@ -780,7 +780,6 @@ static int http_open_network(char *url, FILE **httpfile, char *contentencoding,
   char turl[MAXLEN];
   char *scratchstr;
   char *scratchstr2;
-  char *saveptr;
   int port;
   float version;
 
@@ -2618,7 +2617,9 @@ static int ftp_open_network(char *filename, FILE **ftpfile, FILE **command, int 
   char *newfn;
   char *passive;
   char *tstr;
-  char *saveptr;
+  #ifdef _REENTRANT
+    char *saveptr;
+  #endif
   char ip[SHORTLEN];
   char turl[MAXLEN];
   int port;
@@ -2900,7 +2901,9 @@ int ftp_file_exist(char *filename)
   char *newfn;
   char *passive;
   char *tstr;
-  char *saveptr;
+  #ifdef _REENTRANT
+    char *saveptr;
+  #endif
   char ip[SHORTLEN];
   char turl[MAXLEN];
   int port;

--- a/drvrsmem.c
+++ b/drvrsmem.c
@@ -414,7 +414,7 @@ int     shared_malloc(long size, int mode, int newhandle)               /* retur
       if (shared_debug) printf(" handle=%d", h);
       if (SHARED_INVALID == h) continue;                /* segment already accupied */
       bp = (BLKHEAD *)shmat(h, 0, 0);                   /* try attach */
-      if (shared_debug) printf(" p=%p", bp);
+      if (shared_debug) printf(" p=%p", (void *) bp);
       if (((BLKHEAD *)SHARED_INVALID) == bp)            /* cannot attach, delete segment, try with another key */
         { shmctl(h, IPC_RMID, 0);
           continue;

--- a/editcol.c
+++ b/editcol.c
@@ -1962,17 +1962,11 @@ int ffccls(fitsfile *infptr,    /* I - FITS file pointer to input file  */
   fits_insert_col() multiple times.
 */
 {
-    int tstatus, colnum, typecode, otypecode, anynull;
+    int tstatus, colnum, typecode, otypecode;
     int inHduType, outHduType;
-    long tfields, repeat, orepeat, width, owidth, nrows, outrows;
-    long inloop, outloop, maxloop, ndone, ntodo, npixels;
-    long firstrow, firstelem, ii;
+    long tfields, repeat, orepeat, width, owidth;
     char keyname[FLEN_KEYWORD], ttype[FLEN_VALUE], tform[FLEN_VALUE];
     char ttype_comm[FLEN_COMMENT],tform_comm[FLEN_COMMENT];
-    char *lvalues = 0, nullflag, **strarray = 0;
-    char nulstr[] = {'\5', '\0'};  /* unique null string value */
-    double dnull = 0.l, *dvalues = 0;
-    float fnull = 0., *fvalues = 0;
     int typecodes[1000];
     char *ttypes[1000], *tforms[1000], keyarr[1001][FLEN_CARD];
     int ikey = 0;

--- a/eval.y
+++ b/eval.y
@@ -1664,7 +1664,7 @@ static int New_GTI( ParseData *lParse, funcOp Op, char *fname, int Node1, int No
    int  type,i,n, startCol, stopCol, Node0;
    int  hdutype, hdunum, evthdu, samefile, extvers, movetotype, tstat;
    char extname[100];
-   long nrows;
+   long j, nrows;
    double timeZeroI[2], timeZeroF[2], dt, timeSpan;
    char xcol[20], xexpr[20];
    YYSTYPE colVal;
@@ -1872,10 +1872,10 @@ static int New_GTI( ParseData *lParse, funcOp Op, char *fname, int Node1, int No
 	 /*  Test for fully time-ordered GTI... both START && STOP  */
 
 	 that0->type = 1; /*  Assume yes  */
-	 i = nrows;
-	 while( --i ) { /* the following are failure conditions for GTI ordering */
-	   if( (startptr[i] > stopptr[i]    ) ||    /* START{i} > STOP{i} */
-	       (startptr[i] < stopptr[i-1]) ) {     /* START{i} < STOP{i-1} */
+	 j = nrows;
+	 while( --j ) { /* the following are failure conditions for GTI ordering */
+	   if( (startptr[j] > stopptr[j]    ) ||    /* START{j} > STOP{j} */
+	       (startptr[j] < stopptr[j-1]) ) {     /* START{j} < STOP{j-1} */
 	     that0->type = 0;
 	     break;
 	   }
@@ -1884,7 +1884,7 @@ static int New_GTI( ParseData *lParse, funcOp Op, char *fname, int Node1, int No
 	 /* GTIOVERLAP() requires ordered GTI */
 	 if (that0->type != 1 && Op == gtiover_fct) {
 	   char errmsg[120];
-	   sprintf(errmsg, "Input GTI must be time-ordered for GTIOVERLAP (row %ld)", i+1);
+	   sprintf(errmsg, "Input GTI must be time-ordered for GTIOVERLAP (row %ld)", j+1);
 	   yyerror(0, lParse, errmsg);
 	   return(-1);
 	 }
@@ -4054,7 +4054,6 @@ static void Do_Func( ParseData *lParse, Node *this )
 	   {
 	     long ielem;
 	     long elemnum = 1;
-	     int j;
 
 	     for (ielem = 0; ielem<elem; ielem++) {
 	       this->value.data.lngptr[ielem] = elemnum;
@@ -5643,8 +5642,7 @@ static void Do_GTI_Over( ParseData *lParse, Node *this )
    Node *theTimes, *theStart, *theStop;
    double *gtiStart, *gtiStop;
    double *evtStart, *evtStop;
-   long elem, nGTI, gti, nextGTI;
-   int ordered;
+   long elem, nGTI, gti;
 
    theTimes = lParse->Nodes + this->SubNodes[0]; /* GTI times */
    theStop  = lParse->Nodes + this->SubNodes[2]; /* User start time */
@@ -6001,7 +5999,6 @@ static void Do_Array( ParseData *lParse, Node *this )
 {
    Node *that;
    long row, elem, idx, jdx, offset=0;
-   int node;
 
    Allocate_Ptrs( lParse, this );
 

--- a/eval_y.c
+++ b/eval_y.c
@@ -3902,7 +3902,7 @@ static int New_GTI( ParseData *lParse, funcOp Op, char *fname, int Node1, int No
    int  type,i,n, startCol, stopCol, Node0;
    int  hdutype, hdunum, evthdu, samefile, extvers, movetotype, tstat;
    char extname[100];
-   long nrows;
+   long j, nrows;
    double timeZeroI[2], timeZeroF[2], dt, timeSpan;
    char xcol[20], xexpr[20];
    YYSTYPE colVal;
@@ -4110,10 +4110,10 @@ static int New_GTI( ParseData *lParse, funcOp Op, char *fname, int Node1, int No
 	 /*  Test for fully time-ordered GTI... both START && STOP  */
 
 	 that0->type = 1; /*  Assume yes  */
-	 i = nrows;
-	 while( --i ) { /* the following are failure conditions for GTI ordering */
-	   if( (startptr[i] > stopptr[i]    ) ||    /* START{i} > STOP{i} */
-	       (startptr[i] < stopptr[i-1]) ) {     /* START{i} < STOP{i-1} */
+	 j = nrows;
+	 while( --j ) { /* the following are failure conditions for GTI ordering */
+	   if( (startptr[j] > stopptr[j]    ) ||    /* START{j} > STOP{j} */
+	       (startptr[j] < stopptr[j-1]) ) {     /* START{j} < STOP{j-1} */
 	     that0->type = 0;
 	     break;
 	   }
@@ -4122,7 +4122,7 @@ static int New_GTI( ParseData *lParse, funcOp Op, char *fname, int Node1, int No
 	 /* GTIOVERLAP() requires ordered GTI */
 	 if (that0->type != 1 && Op == gtiover_fct) {
 	   char errmsg[120];
-	   sprintf(errmsg, "Input GTI must be time-ordered for GTIOVERLAP (row %ld)", i+1);
+	   sprintf(errmsg, "Input GTI must be time-ordered for GTIOVERLAP (row %ld)", j+1);
 	   yyerror(0, lParse, errmsg);
 	   return(-1);
 	 }
@@ -6292,7 +6292,6 @@ static void Do_Func( ParseData *lParse, Node *this )
 	   {
 	     long ielem;
 	     long elemnum = 1;
-	     int j;
 
 	     for (ielem = 0; ielem<elem; ielem++) {
 	       this->value.data.lngptr[ielem] = elemnum;
@@ -7881,8 +7880,7 @@ static void Do_GTI_Over( ParseData *lParse, Node *this )
    Node *theTimes, *theStart, *theStop;
    double *gtiStart, *gtiStop;
    double *evtStart, *evtStop;
-   long elem, nGTI, gti, nextGTI;
-   int ordered;
+   long elem, nGTI, gti;
 
    theTimes = lParse->Nodes + this->SubNodes[0]; /* GTI times */
    theStop  = lParse->Nodes + this->SubNodes[2]; /* User start time */
@@ -8238,8 +8236,7 @@ static void Do_Vector( ParseData *lParse, Node *this )
 static void Do_Array( ParseData *lParse, Node *this )
 {
    Node *that;
-   long row, elem, idx, jdx, offset=0;
-   int node;
+   long row, elem, idx, offset=0;
 
    Allocate_Ptrs( lParse, this );
 

--- a/fitscore.c
+++ b/fitscore.c
@@ -1052,7 +1052,9 @@ int ffmkky(const char *keyname,   /* I - keyword name    */
 {
     size_t namelen, len, ii;
     char tmpname[FLEN_KEYWORD], tmpname2[FLEN_KEYWORD],*cptr;
-    char *saveptr;
+    #ifdef _REENTRANT
+        char *saveptr;
+    #endif
     int tstatus = -1, nblank = 0, ntoken = 0, maxlen = 0, specialchar = 0;
 
     if (*status > 0)

--- a/getcoluj.c
+++ b/getcoluj.c
@@ -2882,15 +2882,7 @@ int fffi1u8(unsigned char *input, /* I - array of values to be converted     */
         {       
             for (ii = 0; ii < ntodo; ii++)
 	    {
-	        if (input[ii] < 0) 
-		{
-                   *status = OVERFLOW_ERR;
-                    output[ii] = 0;
-                }
-		else
-		{
-                    output[ii] = (ULONGLONG) input[ii];  /* copy input to output */
-		}
+                output[ii] = (ULONGLONG) input[ii];  /* copy input to output */
 	    }
         }
         else             /* must scale the data */
@@ -2927,11 +2919,6 @@ int fffi1u8(unsigned char *input, /* I - array of values to be converted     */
                         output[ii] = nullval;
                     else
                         nullarray[ii] = 1;
-                }
-                else if (input[ii] < 0) 
-		{
-                   *status = OVERFLOW_ERR;
-                    output[ii] = 0;
                 }
 		else
                     output[ii] = (ULONGLONG) input[ii];

--- a/getkey.c
+++ b/getkey.c
@@ -287,7 +287,6 @@ int ffgky( fitsfile *fptr,     /* I - FITS file pointer        */
 {
     LONGLONG longval;
     ULONGLONG ulongval;
-    double doubleval;
 
     if (*status > 0)           /* inherit input status value if > 0 */
         return(*status);

--- a/group.c
+++ b/group.c
@@ -5397,12 +5397,21 @@ int fits_url2path(char *inpath,  /* input file path string  */
   int absolute;
 
 #if defined(MSDOS) || defined(__WIN32__) || defined(WIN32)
-  char *tmpStr, *saveptr;
+  char *tmpStr;
+  #ifdef _REENTRANT
+    char *saveptr;
+  #endif
 #elif defined(VMS) || defined(vms) || defined(__vms)
   int i;
-  char *tmpStr, *saveptr;
+  char *tmpStr;
+  #ifdef _REENTRANT
+    char *saveptr;
+  #endif
 #elif defined(macintosh)
-  char *tmpStr, *saveptr;
+  char *tmpStr;
+  #ifdef _REENTRANT
+    char *saveptr;
+  #endif
 #endif
 
   if(*status != 0) return(*status);
@@ -6063,7 +6072,9 @@ int fits_clean_url(char *inURL,  /* I input URL string                      */
 {
   grp_stack* mystack; /* stack to hold pieces of URL */
   char* tmp;
-  char *saveptr;
+  #ifdef _REENTRANT
+    char *saveptr;
+  #endif
 
   if(*status) return *status;
 

--- a/group.c
+++ b/group.c
@@ -593,10 +593,11 @@ int ffgtrm(fitsfile *gfptr,  /* FITS file pointer to group                   */
 
       /* loop over all grouping table members and remove them */
 
-      for(i = nmembers; i > 0 && *status == 0; --i)
-	*status = fits_remove_member(gfptr,i,OPT_RM_ENTRY,status);
+      for(i = nmembers; i > 0 && *status == 0; --i) {
+        *status = fits_remove_member(gfptr,i,OPT_RM_ENTRY,status);
+      }
       
-	break;
+	  break;
 
     case OPT_RM_ALL:
 

--- a/grparser.c
+++ b/grparser.c
@@ -516,7 +516,9 @@ int	ngp_extract_tokens(NGP_RAW_LINE *cl)
 
 int	ngp_include_file(char *fname)		/* try to open include file */
  { char *p, *p2, *cp, *envar, envfiles[NGP_MAX_ENVFILES];
-   char *saveptr;
+   #ifdef _REENTRANT
+    char *saveptr;
+   #endif
 
    if (NULL == fname) return(NGP_NUL_PTR);
 

--- a/histo.c
+++ b/histo.c
@@ -709,10 +709,8 @@ int ffhist2e(fitsfile **fptr,  /* IO - pointer to table with X and Y cols;    */
     int   bitpix, colnum[4], wtcolnum;
     long haxes[4];
     double amin[4], amax[4], binsize[4],  weight;
-    int numIterCols = 0;
     int datatypes[4], wtdatatype = 0;
-    long *repeat, wtrepeat = 0;
-    char errmsg[FLEN_ERRMSG];
+    long wtrepeat = 0;
     long vectorRepeat;
 
     if (*status > 0)
@@ -1792,7 +1790,6 @@ int fits_calc_binningde(
     Note: caller is responsible to free parsers[*] upon return using ffcprs()
 */
 {
-    tcolumn *colptr;
     char *cptr, cpref[4][FLEN_VALUE];
     char errmsg[FLEN_ERRMSG], keyname[FLEN_KEYWORD];
     int tstatus, ii;
@@ -2123,7 +2120,7 @@ int fits_calc_binningde(
 	 }
 
          if (tstatus || 
-	     colexpr && colexpr[ii] && colexpr[ii][0]) {
+	     (colexpr && colexpr[ii] && colexpr[ii][0])) {
 	    /* make at least 10 bins */
             binsize[ii] = (amax[ii] - amin[ii]) / 10.F ;
             if (binsize[ii] > 1.)
@@ -2959,11 +2956,9 @@ int fits_get_expr_minmax(fitsfile *fptr, char *expr, double *datamin,
    parseInfo Info;
    ParseData lParse;
    struct histo_minmax_workfn_struct minmaxWorkFn;
-   int naxis, constant, typecode, newNullKwd=0;
-   long nelem, naxes[MAXDIMS], repeat, width, nrows;
-   int col_cnt, colNo;
+   int naxis;
+   long nelem, naxes[MAXDIMS], nrows;
    Node *result;
-   char card[81], tform[16], nullKwd[9], tdimKwd[9];
    double double_nulval = DOUBLENULLVALUE;
 
    if( *status ) return( *status );
@@ -3029,8 +3024,7 @@ int ffwritehisto(long totaln, long pixoffset, long firstn, long nvalues,
    This work function only gets called once, and totaln = nvalues.
 */
 {
-    iteratorCol *colpars;
-    int ii, status = 0, ncols;
+    int status = 0;
     long rows_per_loop = 0, offset = 0;
     histType *histData;
 
@@ -3098,7 +3092,6 @@ int ffcalchist(long totalrows, long offset, long firstrow, long nrows,
 
       /* We have a parser for this, evaluate it */
       if (histData->parsers[ii].nCols > 0) {
-	struct ParseStatusVariables *pv = &(histData->infos[ii].parseVariables);
 	iteratorCol *colData = &(histData->iterCols[startCol]);
 	int nCols = histData->parsers[ii].nCols;
 

--- a/iraffits.c
+++ b/iraffits.c
@@ -1413,7 +1413,9 @@ hgetc (
 	char line[100];
 	char *vpos, *cpar = NULL;
 	char *q1, *q2 = NULL, *v1, *v2, *c1, *brack1, *brack2;
-        char *saveptr;
+    #ifdef _REENTRANT
+	    char *saveptr;
+	#endif
 	int ipar, i;
 
 	squot[0] = 39;

--- a/iter_a.c
+++ b/iter_a.c
@@ -9,9 +9,9 @@
   value for the 'rate' column as a function of the values in the other
   'counts' and 'time' columns.
 */
-main()
+int main()
 {
-    extern flux_rate(); /* external work function is passed to the iterator */
+    extern int flux_rate(); /* external work function is passed to the iterator */
     fitsfile *fptr;
     iteratorCol cols[3];  /* structure used by the iterator function */
     int n_cols;

--- a/iter_b.c
+++ b/iter_b.c
@@ -9,9 +9,9 @@
   type column in a table, and toggles the value in the logical column
   so that T -> F and F -> T.
 */
-main()
+int main()
 {
-    extern str_iter(); /* external work function is passed to the iterator */
+    extern int str_iter(); /* external work function is passed to the iterator */
     fitsfile *fptr;
     iteratorCol cols[2];
     int n_cols;
@@ -76,7 +76,7 @@ int str_iter(long totalrows, long offset, long firstrow, long nrows,
        stringvals       = (char **) fits_iter_get_array(&cols[0]);
        logicalvals      = (char *)  fits_iter_get_array(&cols[1]);
 
-       printf("Total rows, No. rows = %d %d\n",totalrows, nrows);
+       printf("Total rows, No. rows = %ld %ld\n",totalrows, nrows);
     }
 
     /*------------------------------------------*/

--- a/iter_c.c
+++ b/iter_c.c
@@ -22,9 +22,9 @@ long ysize = 480;
 long xbinsize = 32;
 long ybinsize = 32;
 
-main()
+int main()
 {
-    extern writehisto();  /* external work function passed to the iterator */
+    int extern writehisto();    /* external work function passed to the iterator */
     extern long xsize, ysize;  /* size of image */
 
     fitsfile *fptr;
@@ -73,7 +73,7 @@ int writehisto(long totaln, long offset, long firstn, long nvalues,
    This routine is executed only once since nvalues was forced to = totaln.
 */
 {
-    extern calchisto();  /* external function called by the iterator */
+    int extern calchisto(); /* external function called by the iterator */
     long *histogram;
     fitsfile *tblptr;
     iteratorCol cols[2];

--- a/iter_image.c
+++ b/iter_image.c
@@ -8,9 +8,9 @@
   It reads and modifies the input 'iter_image.fit' image file by setting
   all the pixel values to zero (DESTROYING THE ORIGINAL IMAGE!!!)
 */
-main()
+int main()
 {
-    extern zero_image(); /* external work function is passed to the iterator */
+    int extern zero_image(); /* external work function is passed to the iterator */
     fitsfile *fptr;
     iteratorCol cols[3];  /* structure used by the iterator function */
     int n_cols;
@@ -87,7 +87,7 @@ int zero_image(long totalrows, long offset, long firstrow, long nrows,
     {
        counts[ii] = 1.;
     }
-    printf("firstrows, nrows = %d %d\n", firstrow, nrows);
-    
+    printf("firstrows, nrows = %ld %ld\n", firstrow, nrows);
+
     return(0);  /* return successful status */
 }

--- a/iter_var.c
+++ b/iter_var.c
@@ -9,9 +9,9 @@
   value for the 'rate' column as a function of the values in the other
   'counts' and 'time' columns.
 */
-main()
+int main()
 {
-    extern flux_rate(); /* external work function is passed to the iterator */
+    int extern flux_rate(); /* external work function is passed to the iterator */
     fitsfile *fptr;
     iteratorCol cols[3];  /* structure used by the iterator function */
     int n_cols;
@@ -91,8 +91,7 @@ printf("Datatype of column = %d\n",fits_iter_get_datatype(&cols[0]));
     for (ii = 1; ii <= nrows; ii++)
     {
        repeat = fits_iter_get_repeat(&cols[0]);
-       printf ("repeat = %d, %d\n",repeat, counts[1]);
-       
+       printf("repeat = %ld, %d\n", repeat, counts[1]);
     }
 
 

--- a/modkey.c
+++ b/modkey.c
@@ -706,11 +706,8 @@ int ffmkls( fitsfile *fptr,           /* I - FITS file pointer        */
   This routine is not very efficient, so it should be used sparingly.
 */
 {
-    char valstring[FLEN_VALUE];
-    char card[FLEN_CARD], tmpkeyname[FLEN_CARD];
-    char tstring[FLEN_VALUE], *cptr;
+    char card[FLEN_CARD];
     char *comm=0, *tmplongval=0;
-    int next, remain, nquote, nchar, namelen, contin, tstatus = -1;
     int nkeys, keypos;
     int vlen, commlen, tmpvlen, tmpcommlen;
 

--- a/putcoluj.c
+++ b/putcoluj.c
@@ -1012,7 +1012,6 @@ int ffpprujj( fitsfile *fptr,  /* I - FITS file pointer                       */
 */
 {
     long row;
-    unsigned long nullvalue;
 
     /*
       the primary array is represented as a binary table:
@@ -1111,7 +1110,6 @@ int ffp3dujj(fitsfile *fptr,   /* I - FITS file pointer                    */
 */
 {
     long tablerow, ii, jj;
-    long fpixel[3]= {1,1,1}, lpixel[3];
     LONGLONG nfits, narray;
     /*
       the primary array is represented as a binary table:

--- a/putkey.c
+++ b/putkey.c
@@ -418,7 +418,9 @@ int fits_make_longstr_key_util( fitsfile *fptr,     /* I - FITS file pointer    
     char valstring[FLEN_CARD], comstring[FLEN_CARD];
     /* give tmpkeyname same size restriction as in ffmkky */
     char card[FLEN_CARD], tmpkeyname[FLEN_KEYWORD];
-    char tstring[FLEN_CARD], *cptr;
+    char tstring[FLEN_CARD];
+    const char *cptr;
+    char *tmpcptr;
     int next, remainval, remaincom, vlen, nquote, nchar; 
     int namelen, finalnamelen, maxvalchars;
     int contin, tstatus=-1, nocomment=0, ichar, addline=1;
@@ -444,14 +446,16 @@ int fits_make_longstr_key_util( fitsfile *fptr,     /* I - FITS file pointer    
     tmpkeyname[FLEN_KEYWORD-1] = '\0';
     
     namelen = strlen(tmpkeyname);
+    
     if (namelen)         /* skip trailing spaces in name */
     {
-       cptr = tmpkeyname + namelen - 1;
-       while (*cptr == ' ')
+       tmpcptr = tmpkeyname + namelen - 1;
+       while (*tmpcptr == ' ')
        {
-          *cptr = '\0';
-          cptr--;
+          *tmpcptr = '\0';
+          tmpcptr--;
        }
+       cptr = tmpcptr;
        namelen = strlen(tmpkeyname);
     }
     
@@ -2765,7 +2769,6 @@ int ffphbn(fitsfile *fptr,  /* I - FITS file pointer                        */
 
     char tfmt[30], name[FLEN_KEYWORD], comm[FLEN_COMMENT], extnm[FLEN_VALUE];
     char *cptr, card[FLEN_CARD];
-    tcolumn *colptr;
 
     if (*status > 0)
         return(*status);

--- a/quantize.c
+++ b/quantize.c
@@ -3719,10 +3719,8 @@ static float quick_select_float(float arr[], int n)
     ELEM_SWAP(arr[low], arr[hh]) ;
 
     /* Re-set active partition */
-    if (hh <= median)
-        low = ll;
-        if (hh >= median)
-        high = hh - 1;
+    if (hh <= median) low = ll;
+    if (hh >= median) high = hh - 1;
     }
 }
 
@@ -3775,10 +3773,8 @@ static short quick_select_short(short arr[], int n)
     ELEM_SWAP(arr[low], arr[hh]) ;
 
     /* Re-set active partition */
-    if (hh <= median)
-        low = ll;
-        if (hh >= median)
-        high = hh - 1;
+    if (hh <= median) low = ll;
+    if (hh >= median) high = hh - 1;
     }
 }
 
@@ -3831,10 +3827,8 @@ static int quick_select_int(int arr[], int n)
     ELEM_SWAP(arr[low], arr[hh]) ;
 
     /* Re-set active partition */
-    if (hh <= median)
-        low = ll;
-        if (hh >= median)
-        high = hh - 1;
+    if (hh <= median) low = ll;
+    if (hh >= median) high = hh - 1;
     }
 }
 
@@ -3887,10 +3881,8 @@ static LONGLONG quick_select_longlong(LONGLONG arr[], int n)
     ELEM_SWAP(arr[low], arr[hh]) ;
 
     /* Re-set active partition */
-    if (hh <= median)
-        low = ll;
-        if (hh >= median)
-        high = hh - 1;
+    if (hh <= median) low = ll;
+    if (hh >= median) high = hh - 1;
     }
 }
 
@@ -3943,10 +3935,8 @@ static double quick_select_double(double arr[], int n)
     ELEM_SWAP(arr[low], arr[hh]) ;
 
     /* Re-set active partition */
-    if (hh <= median)
-        low = ll;
-        if (hh >= median)
-        high = hh - 1;
+    if (hh <= median) low = ll;
+    if (hh >= median) high = hh - 1;
     }
 }
 

--- a/region.c
+++ b/region.c
@@ -983,7 +983,7 @@ void fits_free_region( SAORegion *Rgn )
 /*   Free up memory allocated to hold the region data.                       
    This is more complicated for the case of polygons, which may be sharing
    points arrays due to shallow copying (in fits_set_region_components) of
-   'exluded' regions.  We must ensure that these arrays are only freed once.       
+   'excluded' regions.  We must ensure that these arrays are only freed once. */       
 
 /*---------------------------------------------------------------------------*/
 {

--- a/utilities/fitsverify.c
+++ b/utilities/fitsverify.c
@@ -21,7 +21,7 @@ int PILPutInt(char *parname, int intvalue);
 int main(int argc, char *argv[])
 {
     int status = 0, invalid = 0, ii, file1 = 0;
-    char *filename, errormode[2] = {"w"};
+    char errormode[2] = {"w"};
 
     if (argc == 2 && !strcmp(argv[1],"-h")) {
 

--- a/utilities/ftverify.c
+++ b/utilities/ftverify.c
@@ -142,6 +142,8 @@ int testhierarch=0;
 int totalhdu=0;
 
 
+static char comm[FLEN_FILENAME+6];
+
 /*---------------------------------------------------------------------------*/
 int ftverify (void)
 {

--- a/utilities/fverify.h
+++ b/utilities/fverify.h
@@ -11,8 +11,6 @@
 #define MAXERRORS  200		
 #define MAXWRNS  200		
 
-static char errmes[256];
-static char comm[FLEN_FILENAME+6];
 extern int prhead;
 extern int testdata;
 extern int testfill;

--- a/utilities/fvrf_data.c
+++ b/utilities/fvrf_data.c
@@ -1,3 +1,5 @@
+#include <ctype.h>
+
 #include "fverify.h"
 typedef struct { 
    int nnum;
@@ -12,6 +14,9 @@ typedef struct {
    FitsHdu *hduptr;
    FILE* out;
 }UserIter;
+
+static char errmes[256];
+static char comm[FLEN_COMMENT];
 
 /*************************************************************
 *

--- a/utilities/fvrf_file.c
+++ b/utilities/fvrf_file.c
@@ -3,6 +3,10 @@ static HduName  **hduname;
 static int total_err=1;  /* initialzed to 1 in case fail to open file */
 static int total_warn=0;
 
+
+static char errmes[256];
+static char comm[FLEN_COMMENT];
+
 int get_total_warn()
 {
     return (total_warn);

--- a/utilities/fvrf_head.c
+++ b/utilities/fvrf_head.c
@@ -27,6 +27,10 @@ static char snull[] = "";
 static int curhdu;			/* current HDU index */
 static int curtype;			/* current HDU type  */
 
+
+static char errmes[256];
+static char comm[FLEN_COMMENT];
+
 /******************************************************************************
 * Function
 *      verify_fits 

--- a/utilities/fvrf_key.c
+++ b/utilities/fvrf_key.c
@@ -1,5 +1,8 @@
 #include "fverify.h"
 
+
+static char errmes[256];
+
 int fits_parse_card(FILE *out,		/* output file pointer */
                     int  kpos,          /* keyposition starting from 1 */
 		    char *card,  	/* key card */

--- a/utilities/smem.c
+++ b/utilities/smem.c
@@ -71,7 +71,7 @@ else if (deletemode) shared_uncond_delete(id);
 
 for (id = 0; id <16; id++) {
   status = shared_getaddr(id, &address);
-  if (!status)printf("id, status, address %d %d %ld %.30s\n", id, status, address, address);
+  if (!status) printf("id, status, address %d %d %p %.30s\n", id, status, (void *) address, address);
 }
 return(0);
 }

--- a/utilities/testprog.c
+++ b/utilities/testprog.c
@@ -893,7 +893,7 @@ int main()
       ############################
     */
     ffcpky(fptr, fptr, 1, 4, "KY_PKNE", &status);
-    ffgkne(fptr, "ky_pkne", 2, 4, inekey, &nfound, &status);
+    ffgkne(fptr, "ky_pkne", 2, 3, inekey, &nfound, &status);
     printf("\nCopied keyword: ffgkne:  %f, %f, %f\n", inekey[0], inekey[1],
            inekey[2]);
 


### PR DESCRIPTION
Closes #55 

I used and cleaned up some of the warnings. It identified the bug in  #55 

```
-std=c99 -Werror -Wall -Wextra -Wno-error=unused-but-set-parameter -Wno-error=unused-parameter -Wno-error=sign-compare -Wno-error=unused-but-set-variable -Wno-error=format-truncation -Wno-error=implicit-fallthrough -Wno-error=unused-function -Wno-error=unused-value -Wno-error=stringop-truncation -Wno-error=format-overflow
```

Also added a disk flush in `speed.c` and fixed an incorrect parameter in `testprog.c`