### PR TITLE
Free memory in editcol - ffcpcl and cookbook - selectrows

### DIFF
--- a/editcol.c
+++ b/editcol.c
@@ -1941,6 +1941,7 @@ int ffcpcl(fitsfile *infptr,    /* I - FITS file pointer to input file  */
     if (ujjvalues) free(ujjvalues);
     if (jjvalues)  free(jjvalues);
     if (dvalues)   free(dvalues);
+    if (fvalues) free(fvalues);
 
     return(*status);
 }

--- a/utilities/cookbook.c
+++ b/utilities/cookbook.c
@@ -365,6 +365,8 @@ void selectrows( void )
     if (fits_close_file(outfptr, &status) || fits_close_file(infptr, &status))
         printerror( status );
 
+    free(buffer);
+        
     return;
 }
 /*--------------------------------------------------------------------------*/


### PR DESCRIPTION
Noticed a missing `free` in a couple of functions