### PR TITLE
Add missing `free`, `fclose` and dangling pointer

### DIFF
--- a/cfileio.c
+++ b/cfileio.c
@@ -2343,7 +2343,8 @@ int ffedit_columns(
                    {
                       ffpmsg("error: column name is too long (ffedit_columns):");
                       if( file_expr ) free( file_expr );
-		      if (clause) free(clause);
+		              if (clause) free(clause);
+                      if (colindex) free(colindex);
                       free(tstbuff);
                       *status=URL_PARSE_ERROR;
 		      return (*status);
@@ -2413,7 +2414,7 @@ int ffedit_columns(
                ffpmsg(cptr2);
                if( colindex ) free( colindex );
                if( file_expr ) free( file_expr );
-	       if (clause) free(clause);
+	           if (clause) free(clause);
                return(*status = URL_PARSE_ERROR);
               }
             }
@@ -2446,7 +2447,8 @@ int ffedit_columns(
                    {
                       ffpmsg("error: column name syntax is too long (ffedit_columns):");
                       if( file_expr ) free( file_expr );
-		      if (clause) free(clause);
+		              if (clause) free(clause);
+                      if (colindex) free(colindex);
                       free(tstbuff);
                       *status=URL_PARSE_ERROR;
 		      return (*status);
@@ -2470,7 +2472,7 @@ int ffedit_columns(
                       ffpmsg(colname);
                       if( colindex ) free( colindex );
                       if( file_expr ) free( file_expr );
-	              if (clause) free(clause);
+	                  if (clause) free(clause);
                       return(*status);
                     }
                     /* keep this column in the output file */
@@ -2491,7 +2493,7 @@ int ffedit_columns(
                         ffpmsg(clause);
                         if( colindex ) free( colindex );
                         if( file_expr ) free( file_expr );
-			if (clause) free(clause);
+			             if (clause) free(clause);
                         return(*status);
                     }
                 }
@@ -2519,7 +2521,7 @@ int ffedit_columns(
                          ffpmsg("column expression is too long (ffedit_columns)");
                          if( colindex ) free( colindex );
                          if( file_expr ) free( file_expr );
-		         if (clause) free(clause);
+		                 if (clause) free(clause);
                          free(tstbuff);
                          *status=URL_PARSE_ERROR;
                          return(*status);
@@ -2542,7 +2544,7 @@ int ffedit_columns(
                             ffpmsg("column expression is too long (ffedit_columns)");
                             if( colindex ) free( colindex );
                             if( file_expr ) free( file_expr );
-		            if (clause) free(clause);
+		                    if (clause) free(clause);
                             free(tstbuff);
                             *status=URL_PARSE_ERROR;
                             return(*status);
@@ -2563,7 +2565,7 @@ int ffedit_columns(
                         ffpmsg("Unable to calculate expression");
                         if( colindex ) free( colindex );
                         if( file_expr ) free( file_expr );
-			if (clause) free(clause);
+			            if (clause) free(clause);
                          return(*status);
                 }
 
@@ -2606,7 +2608,7 @@ int ffedit_columns(
              ffpmsg(clause);
              if( colindex ) free( colindex );
              if( file_expr ) free( file_expr );
-	     if (clause) free(clause);
+	         if (clause) free(clause);
              return(*status);
            }
          }
@@ -5534,6 +5536,7 @@ int ffifile2(char *url,       /* input filename */
         {
             if (ptr2-ptr1+3 >= MAX_PREFIX_LEN)
             {
+               free(infile);
                ffpmsg("Name of urltype is too long.");
                return(*status = URL_PARSE_ERROR);
             }
@@ -5611,6 +5614,7 @@ int ffifile2(char *url,       /* input filename */
                 if (infilex) {
 
                     if (strlen(ptr1) > FLEN_FILENAME - 1) {
+                        free(infile);
                         ffpmsg("Name of file is too long.");
                         return(*status = URL_PARSE_ERROR);
                     }

--- a/cfileio.c
+++ b/cfileio.c
@@ -2343,7 +2343,7 @@ int ffedit_columns(
                    {
                       ffpmsg("error: column name is too long (ffedit_columns):");
                       if( file_expr ) free( file_expr );
-		              if (clause) free(clause);
+		      if (clause) free(clause);
                       if (colindex) free(colindex);
                       free(tstbuff);
                       *status=URL_PARSE_ERROR;
@@ -2414,7 +2414,7 @@ int ffedit_columns(
                ffpmsg(cptr2);
                if( colindex ) free( colindex );
                if( file_expr ) free( file_expr );
-	           if (clause) free(clause);
+	       if (clause) free(clause);
                return(*status = URL_PARSE_ERROR);
               }
             }
@@ -2447,7 +2447,7 @@ int ffedit_columns(
                    {
                       ffpmsg("error: column name syntax is too long (ffedit_columns):");
                       if( file_expr ) free( file_expr );
-		              if (clause) free(clause);
+		      if (clause) free(clause);
                       if (colindex) free(colindex);
                       free(tstbuff);
                       *status=URL_PARSE_ERROR;
@@ -2472,7 +2472,7 @@ int ffedit_columns(
                       ffpmsg(colname);
                       if( colindex ) free( colindex );
                       if( file_expr ) free( file_expr );
-	                  if (clause) free(clause);
+	              if (clause) free(clause);
                       return(*status);
                     }
                     /* keep this column in the output file */
@@ -2493,7 +2493,7 @@ int ffedit_columns(
                         ffpmsg(clause);
                         if( colindex ) free( colindex );
                         if( file_expr ) free( file_expr );
-			             if (clause) free(clause);
+			if (clause) free(clause);
                         return(*status);
                     }
                 }
@@ -2521,7 +2521,7 @@ int ffedit_columns(
                          ffpmsg("column expression is too long (ffedit_columns)");
                          if( colindex ) free( colindex );
                          if( file_expr ) free( file_expr );
-		                 if (clause) free(clause);
+		         if (clause) free(clause);
                          free(tstbuff);
                          *status=URL_PARSE_ERROR;
                          return(*status);
@@ -2544,7 +2544,7 @@ int ffedit_columns(
                             ffpmsg("column expression is too long (ffedit_columns)");
                             if( colindex ) free( colindex );
                             if( file_expr ) free( file_expr );
-		                    if (clause) free(clause);
+		            if (clause) free(clause);
                             free(tstbuff);
                             *status=URL_PARSE_ERROR;
                             return(*status);
@@ -2565,7 +2565,7 @@ int ffedit_columns(
                         ffpmsg("Unable to calculate expression");
                         if( colindex ) free( colindex );
                         if( file_expr ) free( file_expr );
-			            if (clause) free(clause);
+			if (clause) free(clause);
                          return(*status);
                 }
 
@@ -2608,7 +2608,7 @@ int ffedit_columns(
              ffpmsg(clause);
              if( colindex ) free( colindex );
              if( file_expr ) free( file_expr );
-	         if (clause) free(clause);
+	     if (clause) free(clause);
              return(*status);
            }
          }

--- a/drvrmem.c
+++ b/drvrmem.c
@@ -166,6 +166,7 @@ int mem_create_comp(char *filename, int *handle)
 
     if (status)
     {
+        fclose(diskfile);  /* close the disk file */
         ffpmsg("failed to create empty memory file (mem_create_comp)");
         return(status);
     }

--- a/drvrmem.c
+++ b/drvrmem.c
@@ -166,7 +166,9 @@ int mem_create_comp(char *filename, int *handle)
 
     if (status)
     {
-        fclose(diskfile);  /* close the disk file */
+        if (diskfile != stdout) 
+          fclose(diskfile);  /* close the disk file */
+
         ffpmsg("failed to create empty memory file (mem_create_comp)");
         return(status);
     }

--- a/editcol.c
+++ b/editcol.c
@@ -481,6 +481,8 @@ and gives a list of rows or row ranges separated by commas.
 
     rowarray = calloc(nrows, sizeof(long));
     if (!rowarray) {
+        free(maxrow);
+        free(minrow);
         *status = MEMORY_ALLOCATION;
         ffpmsg("failed to allocate memory for row array (ffdrrg)");
         return(*status);

--- a/eval_f.c
+++ b/eval_f.c
@@ -279,6 +279,7 @@ int ffsrow( fitsfile *infptr,   /* I - Input FITS file                      */
       rdlen  = (long) inExt.rowLength;
       buffer = (unsigned char *)malloc(maxvalue(500000,rdlen) * sizeof(char) );
       if( buffer==NULL ) {
+         FREE(Info.dataPtr);
          ffcprs(&lParse);
          return( *status=MEMORY_ALLOCATION );
       }

--- a/fits_hcompress.c
+++ b/fits_hcompress.c
@@ -723,7 +723,8 @@ int stat;
 	 * write nbitplanes
 	 */
 	if (0 == qwrite(outfile, (char *) nbitplanes, sizeof(nbitplanes))) {
-	        *nlength = noutchar;
+		free(signbits);
+	    *nlength = noutchar;
 		ffpmsg("encode: output buffer too small");
 		return(DATA_COMPRESSION_ERR);
         }
@@ -885,7 +886,8 @@ int stat;
 	 */
 
 	if (0 == qwrite(outfile, (char *) nbitplanes, sizeof(nbitplanes))) {
-	        *nlength = noutchar;
+		free(signbits);
+		*nlength = noutchar;
 		ffpmsg("encode: output buffer too small");
 		return(DATA_COMPRESSION_ERR);
         }
@@ -1311,9 +1313,14 @@ unsigned char *scratch, *buffer;
 	 * Buffer is used to store string of codes for output.
 	 */
 	scratch = (unsigned char *) malloc(2*bmax);
+	if (scratch == (unsigned char *) NULL) {		
+		ffpmsg("qtree_encode: insufficient memory");
+		return(DATA_COMPRESSION_ERR);
+	}
+
 	buffer = (unsigned char *) malloc(bmax);
-	if ((scratch == (unsigned char *) NULL) ||
-		(buffer  == (unsigned char *) NULL)) {		
+	if (buffer  == (unsigned char *) NULL) {		
+		free(scratch);
 		ffpmsg("qtree_encode: insufficient memory");
 		return(DATA_COMPRESSION_ERR);
 	}
@@ -1430,12 +1437,18 @@ unsigned char *scratch, *buffer;
 	 * Buffer is used to store string of codes for output.
 	 */
 	scratch = (unsigned char *) malloc(2*bmax);
-	buffer = (unsigned char *) malloc(bmax);
-	if ((scratch == (unsigned char *) NULL) ||
-		(buffer  == (unsigned char *) NULL)) {
+	if (scratch == (unsigned char *) NULL)  {
 		ffpmsg("qtree_encode64: insufficient memory");
 		return(DATA_COMPRESSION_ERR);
 	}
+
+	buffer = (unsigned char *) malloc(bmax);
+	if (buffer  == (unsigned char *) NULL) {
+		free(scratch);
+		ffpmsg("qtree_encode64: insufficient memory");
+		return(DATA_COMPRESSION_ERR);
+	}
+
 	/*
 	 * now encode each bit plane, starting with the top
 	 */

--- a/fits_hcompress.c
+++ b/fits_hcompress.c
@@ -724,7 +724,7 @@ int stat;
 	 */
 	if (0 == qwrite(outfile, (char *) nbitplanes, sizeof(nbitplanes))) {
 		free(signbits);
-	    *nlength = noutchar;
+		*nlength = noutchar;
 		ffpmsg("encode: output buffer too small");
 		return(DATA_COMPRESSION_ERR);
         }
@@ -1319,7 +1319,7 @@ unsigned char *scratch, *buffer;
 	}
 
 	buffer = (unsigned char *) malloc(bmax);
-	if (buffer  == (unsigned char *) NULL) {		
+	if (buffer  == (unsigned char *) NULL) {
 		free(scratch);
 		ffpmsg("qtree_encode: insufficient memory");
 		return(DATA_COMPRESSION_ERR);

--- a/fits_hdecompress.c
+++ b/fits_hdecompress.c
@@ -1329,6 +1329,7 @@ unsigned char *scratch;
 			 */
 			read_bdirect(infile,a,n,nqx,nqy,scratch,bit);
 		} else if (b != 0xf) {
+			free(scratch);
 			ffpmsg("qtree_decode: bad format code");
 			return(DATA_DECOMPRESSION_ERR);
 		} else {
@@ -1419,6 +1420,7 @@ unsigned char *scratch;
 			 */
 			read_bdirect64(infile,a,n,nqx,nqy,scratch,bit);
 		} else if (b != 0xf) {
+			free(scratch);
 			ffpmsg("qtree_decode64: bad format code");
 			return(DATA_DECOMPRESSION_ERR);
 		} else {

--- a/fitscore.c
+++ b/fitscore.c
@@ -756,7 +756,8 @@ PutMark    6  add a marker to the stack
 {
     int ii;
     char markflag;
-    static char *txtbuff[errmsgsiz], *tmpbuff, *msgptr;
+    static char *txtbuff[errmsgsiz], *tmpbuff;
+    char *msgptr;
     static char errbuff[errmsgsiz][81];  /* initialize all = \0 */
     static int nummsg = 0;
 

--- a/imcompress.c
+++ b/imcompress.c
@@ -1968,6 +1968,7 @@ int imcomp_compress_tile (fitsfile *outfptr,
                 if (idata[ii] < 0 || idata[ii] > 16777215)
                 {
                    /* plio algorithn only supports positive 24 bit ints */
+                   free(cbuf);
                    ffpmsg("data out of range for PLIO compression (0 - 2**24)");
                    return(*status = DATA_COMPRESSION_ERR);
                 }
@@ -2074,6 +2075,7 @@ int imcomp_compress_tile (fitsfile *outfptr,
 	         (char *) idata, (unsigned int) (tilelen * intlength), 9, 0, 0) ) 
 */
 	   {
+                   free(cbuf);
                    ffpmsg("bzip2 compression error");
                    return(*status = DATA_COMPRESSION_ERR);
            }

--- a/iraffits.c
+++ b/iraffits.c
@@ -286,7 +286,7 @@ static char *irafrdhead (
     /* Find size of image header file */
     if (fseek(fd, 0, 2) != 0)  /* move to end of the file */
     {
-		fclose(fd);
+    fclose(fd);
         ffpmsg("IRAFRHEAD: cannot seek in file:");
         ffpmsg(filename);
         return(NULL);
@@ -295,7 +295,7 @@ static char *irafrdhead (
     nbhead = ftell(fd);     /* position = size of file */
     if (nbhead < 0)
     {
-		fclose(fd);
+    fclose(fd);
         ffpmsg("IRAFRHEAD: cannot get pos. in file:");
         ffpmsg(filename);
         return(NULL);
@@ -303,7 +303,7 @@ static char *irafrdhead (
 
     if (fseek(fd, 0, 0) != 0) /* move back to beginning */
     {
-		fclose(fd);
+    fclose(fd);
         ffpmsg("IRAFRHEAD: cannot seek to beginning of file:");
         ffpmsg(filename);
         return(NULL);
@@ -313,7 +313,7 @@ static char *irafrdhead (
     nihead = nbhead + 5000;
     irafheader = (char *) calloc (1, nihead);
     if (irafheader == NULL) {
-		fclose(fd);
+    fclose(fd);
 	snprintf(errmsg, FLEN_ERRMSG,"IRAFRHEAD Cannot allocate %d-byte header",
 		      nihead);
         ffpmsg(errmsg);

--- a/iraffits.c
+++ b/iraffits.c
@@ -286,6 +286,7 @@ static char *irafrdhead (
     /* Find size of image header file */
     if (fseek(fd, 0, 2) != 0)  /* move to end of the file */
     {
+		fclose(fd);
         ffpmsg("IRAFRHEAD: cannot seek in file:");
         ffpmsg(filename);
         return(NULL);
@@ -294,6 +295,7 @@ static char *irafrdhead (
     nbhead = ftell(fd);     /* position = size of file */
     if (nbhead < 0)
     {
+		fclose(fd);
         ffpmsg("IRAFRHEAD: cannot get pos. in file:");
         ffpmsg(filename);
         return(NULL);
@@ -301,6 +303,7 @@ static char *irafrdhead (
 
     if (fseek(fd, 0, 0) != 0) /* move back to beginning */
     {
+		fclose(fd);
         ffpmsg("IRAFRHEAD: cannot seek to beginning of file:");
         ffpmsg(filename);
         return(NULL);
@@ -310,6 +313,7 @@ static char *irafrdhead (
     nihead = nbhead + 5000;
     irafheader = (char *) calloc (1, nihead);
     if (irafheader == NULL) {
+		fclose(fd);
 	snprintf(errmsg, FLEN_ERRMSG,"IRAFRHEAD Cannot allocate %d-byte header",
 		      nihead);
         ffpmsg(errmsg);

--- a/putcol.c
+++ b/putcol.c
@@ -1561,7 +1561,7 @@ int ffiter(int n_cols,
 
               if (cols[jj].iotype == OutputCol) {
                 free(col);
- 	              snprintf(message,FLEN_ERRMSG,
+                snprintf(message,FLEN_ERRMSG,
                 "Variable length array not allowed for output column number %d (ffiter)",
                     jj + 1);
                 ffpmsg(message);

--- a/putcol.c
+++ b/putcol.c
@@ -1560,7 +1560,8 @@ int ffiter(int n_cols,
 	       negative type code value. */
 
               if (cols[jj].iotype == OutputCol) {
- 	        snprintf(message,FLEN_ERRMSG,
+                free(col);
+ 	              snprintf(message,FLEN_ERRMSG,
                 "Variable length array not allowed for output column number %d (ffiter)",
                     jj + 1);
                 ffpmsg(message);

--- a/zcompress.c
+++ b/zcompress.c
@@ -95,7 +95,10 @@ int uncompress2mem(char *filename,  /* name of input file                 */
        decompressor that we are to use the gzip algorithm */
 
     err = inflateInit2(&d_stream, (15+16));
-    if (err != Z_OK) return(*status = 414);
+    if (err != Z_OK) {
+        free(filebuff);
+        return(*status = 414);
+    }
 
     /* loop through the file, reading a buffer and uncompressing it */
     for (;;)
@@ -277,7 +280,10 @@ int uncompress2file(char *filename,  /* name of input file                  */
     if (!infilebuff) return(*status = 113); /* memory error */
 
     outfilebuff = (char*)malloc(GZBUFSIZE);
-    if (!outfilebuff) return(*status = 113); /* memory error */
+    if (!outfilebuff) {
+        free(infilebuff);
+        return(*status = 113); /* memory error */
+    }
 
     d_stream.zalloc = (alloc_func)0;
     d_stream.zfree = (free_func)0;
@@ -290,7 +296,10 @@ int uncompress2file(char *filename,  /* name of input file                  */
        decompressor that we are to use the gzip algorithm */
 
     err = inflateInit2(&d_stream, (15+16));
-    if (err != Z_OK) return(*status = 414);
+    if (err != Z_OK) {
+        free(infilebuff);
+        return(*status = 414);
+    }
 
     /* loop through the file, reading a buffer and uncompressing it */
     for (;;)
@@ -476,7 +485,10 @@ int compress2file_from_mem(
     err = deflateInit2(&c_stream, Z_BEST_SPEED, Z_DEFLATED,
                        (15+16), 8, Z_DEFAULT_STRATEGY);
 
-    if (err != Z_OK) return(*status = 413);
+    if (err != Z_OK) {
+        free(outfilebuff);
+        return(*status = 413);
+    }
 
     if (inmemsize > 0)
        nPages = 1 + (uLong)(inmemsize-1)/(uLong)UINT_MAX;


### PR DESCRIPTION
Used clang-tiny to find:
- potential memory leaks
- unclosed streams
- dangling pointers

Please take a close look at the `fitscore.c` change as it's in a core code path. 

Best efforts on tabs vs spaces. The repo is completely scattered with different code styles so hard to keep track.