### PR TITLE
Remove usage of function declarations with identifier lists

### DIFF
--- a/iraffits.c
+++ b/iraffits.c
@@ -1307,16 +1307,16 @@ static int lhead0 = 0;
 /* Extract long value for variable from FITS header string */
 
 static int
-hgeti4 (hstring,keyword,ival)
-
-char *hstring;	/* character string containing FITS header information
-		   in the format <keyword>= <value> {/ <comment>} */
-char *keyword;	/* character string containing the name of the keyword
-		   the value of which is returned.  hget searches for a
-		   line beginning with this string.  if "[n]" is present,
-		   the n'th token in the value is returned.
-		   (the first 8 characters must be unique) */
-int *ival;
+hgeti4 (
+    char *hstring, /* character string containing FITS header information
+                      in the format <keyword>= <value> {/ <comment>} */
+    char *keyword, /* character string containing the name of the keyword
+                      the value of which is returned.  hget searches for a
+                      line beginning with this string.  if "[n]" is present,
+                      the n'th token in the value is returned.
+                      (the first 8 characters must be unique) */
+    int *ival
+)
 {
 char *value;
 double dval;
@@ -1352,17 +1352,17 @@ char val[30];
 /* Extract string value for variable from FITS header string */
 
 static int
-hgets (hstring, keyword, lstr, str)
-
-char *hstring;	/* character string containing FITS header information
-		   in the format <keyword>= <value> {/ <comment>} */
-char *keyword;	/* character string containing the name of the keyword
-		   the value of which is returned.  hget searches for a
-		   line beginning with this string.  if "[n]" is present,
-		   the n'th token in the value is returned.
-		   (the first 8 characters must be unique) */
-int lstr;	/* Size of str in characters */
-char *str;	/* String (returned) */
+hgets (
+  char *hstring,  /* character string containing FITS header information
+                     in the format <keyword>= <value> {/ <comment>} */
+  char *keyword,  /* character string containing the name of the keyword
+                     the value of which is returned.  hget searches for a
+                     line beginning with this string.  if "[n]" is present,
+                     the n'th token in the value is returned.
+                     (the first 8 characters must be unique) */
+  int lstr,       /* Size of str in characters */
+  char *str       /* String (returned) */
+)
 {
 	char *value;
 	int lval;
@@ -1391,15 +1391,15 @@ char *str;	/* String (returned) */
 /* Extract character value for variable from FITS header string */
 
 static char *
-hgetc (hstring,keyword0)
-
-char *hstring;	/* character string containing FITS header information
-		   in the format <keyword>= <value> {/ <comment>} */
-char *keyword0;	/* character string containing the name of the keyword
-		   the value of which is returned.  hget searches for a
-		   line beginning with this string.  if "[n]" is present,
-		   the n'th token in the value is returned.
-		   (the first 8 characters must be unique) */
+hgetc (
+  char *hstring, /* character string containing FITS header information
+                    in the format <keyword>= <value> {/ <comment>} */
+  char *keyword0 /* character string containing the name of the keyword
+                    the value of which is returned.  hget searches for a
+                    line beginning with this string.  if "[n]" is present,
+                    the n'th token in the value is returned.
+                    (the first 8 characters must be unique) */
+)
 {
 	static char cval[80];
 	char *value;
@@ -1541,23 +1541,22 @@ char *keyword0;	/* character string containing the name of the keyword
 /*-------------------------------------------------------------------*/
 /* Find beginning of fillable blank line before FITS header keyword line */
 
-static char *
-blsearch (hstring,keyword)
-
 /* Find entry for keyword keyword in FITS header string hstring.
    (the keyword may have a maximum of eight letters)
    NULL is returned if the keyword is not found */
-
-char *hstring;	/* character string containing fits-style header
-		information in the format <keyword>= <value> {/ <comment>}
-		the default is that each entry is 80 characters long;
-		however, lines may be of arbitrary length terminated by
-		nulls, carriage returns or linefeeds, if packed is true.  */
-char *keyword;	/* character string containing the name of the variable
-		to be returned.  ksearch searches for a line beginning
-		with this string.  The string may be a character
-		literal or a character variable terminated by a null
-		or '$'.  it is truncated to 8 characters. */
+static char *
+blsearch (
+  char *hstring, /* character string containing fits-style header
+                    information in the format <keyword>= <value> {/ <comment>}
+                    the default is that each entry is 80 characters long;
+                    however, lines may be of arbitrary length terminated by
+                    nulls, carriage returns or linefeeds, if packed is true.  */
+  char *keyword  /* character string containing the name of the variable
+                    to be returned.  ksearch searches for a line beginning
+                    with this string.  The string may be a character
+                    literal or a character variable terminated by a null
+                    or '$'.  it is truncated to 8 characters. */
+)
 {
     char *loc, *headnext, *headlast, *pval, *lc, *line;
     char *bval;
@@ -1638,22 +1637,21 @@ char *keyword;	/* character string containing the name of the variable
 /*-------------------------------------------------------------------*/
 /* Find FITS header line containing specified keyword */
 
-static char *ksearch (hstring,keyword)
-
 /* Find entry for keyword keyword in FITS header string hstring.
    (the keyword may have a maximum of eight letters)
    NULL is returned if the keyword is not found */
-
-char *hstring;	/* character string containing fits-style header
-		information in the format <keyword>= <value> {/ <comment>}
-		the default is that each entry is 80 characters long;
-		however, lines may be of arbitrary length terminated by
-		nulls, carriage returns or linefeeds, if packed is true.  */
-char *keyword;	/* character string containing the name of the variable
-		to be returned.  ksearch searches for a line beginning
-		with this string.  The string may be a character
-		literal or a character variable terminated by a null
-		or '$'.  it is truncated to 8 characters. */
+static char *ksearch (
+  char *hstring, /* character string containing fits-style header
+                    information in the format <keyword>= <value> {/ <comment>}
+                    the default is that each entry is 80 characters long;
+                    however, lines may be of arbitrary length terminated by
+                    nulls, carriage returns or linefeeds, if packed is true.  */
+  char *keyword  /* character string containing the name of the variable
+                    to be returned.  ksearch searches for a line beginning
+                    with this string.  The string may be a character
+                    literal or a character variable terminated by a null
+                    or '$'.  it is truncated to 8 characters. */
+)
 {
     char *loc, *headnext, *headlast, *pval, *lc, *line;
     int icol, nextchar, lkey, nleft, lhstr;
@@ -1717,11 +1715,10 @@ char *keyword;	/* character string containing the name of the variable
 /* Find string s2 within null-terminated string s1 */
 
 static char *
-strsrch (s1, s2)
-
-char *s1;	/* String to search */
-char *s2;	/* String to look for */
-
+strsrch (
+  char *s1, /* String to search */
+  char *s2  /* String to look for */
+)
 {
     int ls1;
     ls1 = strlen (s1);
@@ -1732,12 +1729,11 @@ char *s2;	/* String to look for */
 /* Find string s2 within string s1 */
 
 static char *
-strnsrch (s1, s2, ls1)
-
-char	*s1;	/* String to search */
-char	*s2;	/* String to look for */
-int	ls1;	/* Length of string being searched */
-
+strnsrch (
+  char *s1, /* String to search */
+  char *s2, /* String to look for */
+  int ls1   /* Length of string being searched */
+)
 {
     char *s,*s1e;
     char cfirst,clast;
@@ -1797,18 +1793,17 @@ int	ls1;	/* Length of string being searched */
 /*  HPUTI4 - Set int keyword = ival in FITS header string */
 
 static void
-hputi4 (hstring,keyword,ival)
-
-  char *hstring;	/* character string containing FITS-style header
-			   information in the format
-			   <keyword>= <value> {/ <comment>}
-			   each entry is padded with spaces to 80 characters */
-
-  char *keyword;		/* character string containing the name of the variable
-			   to be returned.  hput searches for a line beginning
-			   with this string, and if there isn't one, creates one.
-		   	   The first 8 characters of keyword must be unique. */
-  int ival;		/* int number */
+hputi4 (
+  char *hstring, /* character string containing FITS-style header
+                    information in the format
+                    <keyword>= <value> {/ <comment>}
+                    each entry is padded with spaces to 80 characters */
+  char *keyword, /* character string containing the name of the variable
+                    to be returned.  hput searches for a line beginning
+                    with this string, and if there isn't one, creates one.
+                    The first 8 characters of keyword must be unique. */
+  int ival       /* int number */
+)
 {
     char value[30];
 
@@ -1827,11 +1822,11 @@ hputi4 (hstring,keyword,ival)
 /*  HPUTL - Set keyword = F if lval=0, else T, in FITS header string */
 
 static void
-hputl (hstring, keyword,lval)
-
-char *hstring;		/* FITS header */
-char *keyword;		/* Keyword name */
-int lval;		/* logical variable (0=false, else true) */
+hputl (
+  char *hstring, /* FITS header */
+  char *keyword, /* Keyword name */
+  int lval       /* logical variable (0=false, else true) */
+)
 {
     char value[8];
 
@@ -1853,12 +1848,12 @@ int lval;		/* logical variable (0=false, else true) */
 /*  HPUTS - Set character string keyword = 'cval' in FITS header string */
 
 static void
-hputs (hstring,keyword,cval)
-
-char *hstring;	/* FITS header */
-char *keyword;	/* Keyword name */
-char *cval;	/* character string containing the value for variable
-		   keyword.  trailing and leading blanks are removed.  */
+hputs (
+  char *hstring, /* FITS header */
+  char *keyword, /* Keyword name */
+  char *cval    /* character string containing the value for variable
+                   keyword.  trailing and leading blanks are removed.  */
+)
 {
     char squot = 39;
     char value[70];
@@ -1887,12 +1882,12 @@ char *cval;	/* character string containing the value for variable
 /*  HPUTC - Set character string keyword = value in FITS header string */
 
 static void
-hputc (hstring,keyword,value)
-
-char *hstring;
-char *keyword;
-char *value;	/* character string containing the value for variable
-		   keyword.  trailing and leading blanks are removed.  */
+hputc (
+  char *hstring,
+  char *keyword,
+  char *value    /* character string containing the value for variable
+                    keyword.  trailing and leading blanks are removed.  */
+)
 {
     char squot = 39;
     char line[100];
@@ -2029,11 +2024,7 @@ char *value;	/* character string containing the value for variable
 /*  HPUTCOM - Set comment for keyword or on line in FITS header string */
 
 static void
-hputcom (hstring,keyword,comment)
-
-  char *hstring;
-  char *keyword;
-  char *comment;
+hputcom (char *hstring, char *keyword, char *comment)
 {
 	char squot;
 	char line[100];


### PR DESCRIPTION
Closes #62 

This was an old syntax (usually referred to as K&R functions) that is being dropped in C23. Thus cfitsio was failing to compile with newer compilers when targeting the latest standard.

This commit ports all such functions declarations to use the otherwise normal function declaration syntax, where each argument is immediately given its type. After this change code compiles successfully.