### PR TITLE
Add #ifdef _REENTRANT around saveptr declarations to clean up compiler warnings

### DIFF
--- a/cfileio.c
+++ b/cfileio.c
@@ -420,7 +420,9 @@ int ffeopn(fitsfile **fptr,      /* O - FITS file pointer                   */
 {
     int hdunum, naxis = 0, thdutype, gotext=0;
     char *ext, *textlist;
+    #ifdef _REENTRANT
     char *saveptr;
+    #endif
   
     if (*status > 0)
         return(*status);

--- a/drvrnet.c
+++ b/drvrnet.c
@@ -780,7 +780,6 @@ static int http_open_network(char *url, FILE **httpfile, char *contentencoding,
   char turl[MAXLEN];
   char *scratchstr;
   char *scratchstr2;
-  char *saveptr;
   int port;
   float version;
 
@@ -2619,7 +2618,9 @@ static int ftp_open_network(char *filename, FILE **ftpfile, FILE **command, int 
   char *newfn;
   char *passive;
   char *tstr;
+  #ifdef _REENTRANT
   char *saveptr;
+  #endif
   char ip[SHORTLEN];
   char turl[MAXLEN];
   int port;
@@ -2901,7 +2902,9 @@ int ftp_file_exist(char *filename)
   char *newfn;
   char *passive;
   char *tstr;
+  #ifdef _REENTRANT
   char *saveptr;
+  #endif
   char ip[SHORTLEN];
   char turl[MAXLEN];
   int port;

--- a/fitscore.c
+++ b/fitscore.c
@@ -1052,7 +1052,9 @@ int ffmkky(const char *keyname,   /* I - keyword name    */
 {
     size_t namelen, len, ii;
     char tmpname[FLEN_KEYWORD], tmpname2[FLEN_KEYWORD],*cptr;
+    #ifdef _REENTRANT
     char *saveptr;
+    #endif
     int tstatus = -1, nblank = 0, ntoken = 0, maxlen = 0, specialchar = 0;
 
     if (*status > 0)

--- a/group.c
+++ b/group.c
@@ -5396,12 +5396,21 @@ int fits_url2path(char *inpath,  /* input file path string  */
   int absolute;
 
 #if defined(MSDOS) || defined(__WIN32__) || defined(WIN32)
-  char *tmpStr, *saveptr;
+  char *tmpStr;
+  #ifdef _REENTRANT
+  char *saveptr;
+  #endif
 #elif defined(VMS) || defined(vms) || defined(__vms)
   int i;
-  char *tmpStr, *saveptr;
+  char *tmpStr;
+  #ifdef _REENTRANT
+  char *saveptr;
+  #endif
 #elif defined(macintosh)
-  char *tmpStr, *saveptr;
+  char *tmpStr;
+  #ifdef _REENTRANT
+  char *saveptr;
+  #endif
 #endif
 
   if(*status != 0) return(*status);
@@ -6062,7 +6071,9 @@ int fits_clean_url(char *inURL,  /* I input URL string                      */
 {
   grp_stack* mystack; /* stack to hold pieces of URL */
   char* tmp;
+  #ifdef _REENTRANT
   char *saveptr;
+  #endif
 
   if(*status) return *status;
 

--- a/grparser.c
+++ b/grparser.c
@@ -516,7 +516,9 @@ int	ngp_extract_tokens(NGP_RAW_LINE *cl)
 
 int	ngp_include_file(char *fname)		/* try to open include file */
  { char *p, *p2, *cp, *envar, envfiles[NGP_MAX_ENVFILES];
+   #ifdef _REENTRANT
    char *saveptr;
+   #endif
 
    if (NULL == fname) return(NGP_NUL_PTR);
 

--- a/iraffits.c
+++ b/iraffits.c
@@ -1413,7 +1413,9 @@ hgetc (
 	char line[100];
 	char *vpos, *cpar = NULL;
 	char *q1, *q2 = NULL, *v1, *v2, *c1, *brack1, *brack2;
-        char *saveptr;
+	#ifdef _REENTRANT
+	char *saveptr;
+	#endif
 	int ipar, i;
 
 	squot[0] = 39;


### PR DESCRIPTION
Clean up warnings around unused variable `saveptr` for non-reentrant build.

Related #16 