### PR TITLE
Update gitignore with missing example binaries and misc build folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,11 @@
 libtool
 utilities/.deps/
 utilities/.dirstamp
+.vscode/
+build/
+include/
+*.lis
+
 
 # Kernel Module Compile Results
 *.mod*
@@ -79,3 +84,8 @@ imcopy
 smem
 speed
 testprog
+iter_a
+iter_b
+iter_c
+iter_image
+iter_var


### PR DESCRIPTION
- Added some of the build folders / ide folders
- Added *.lis which is frequently used in testing
- Added the iter_* example binaries