### PR TITLE
Fix warnings / invalid logic related to signedness

### DIFF
--- a/getcoluj.c
+++ b/getcoluj.c
@@ -2882,15 +2882,7 @@ int fffi1u8(unsigned char *input, /* I - array of values to be converted     */
         {       
             for (ii = 0; ii < ntodo; ii++)
 	    {
-	        if (input[ii] < 0) 
-		{
-                   *status = OVERFLOW_ERR;
-                    output[ii] = 0;
-                }
-		else
-		{
-                    output[ii] = (ULONGLONG) input[ii];  /* copy input to output */
-		}
+                output[ii] = (ULONGLONG) input[ii];  /* copy input to output */
 	    }
         }
         else             /* must scale the data */
@@ -2927,11 +2919,6 @@ int fffi1u8(unsigned char *input, /* I - array of values to be converted     */
                         output[ii] = nullval;
                     else
                         nullarray[ii] = 1;
-                }
-                else if (input[ii] < 0) 
-		{
-                   *status = OVERFLOW_ERR;
-                    output[ii] = 0;
                 }
 		else
                     output[ii] = (ULONGLONG) input[ii];

--- a/imcompress.c
+++ b/imcompress.c
@@ -8721,7 +8721,7 @@ int fits_uncompress_table(fitsfile *infptr, fitsfile *outfptr, int *status)
 */
 { 
     char colcode[999];  /* column data type code character */
-    char coltype[999];  /* column data type numeric code value */
+    int coltype[999];  /* column data type numeric code value */
     char *cm_buffer;   /* memory buffer for the transposed, Column-Major, chunk of the table */ 
     char *rm_buffer;   /* memory buffer for the original, Row-Major, chunk of the table */ 
     LONGLONG nrows, rmajor_colwidth[999], rmajor_colstart[1000], cmajor_colstart[1000];


### PR DESCRIPTION
- No need to specifically handle <0 case given `input` is unsigned in `fffi1u8`
- Need to specify `signed` for `coltype` in `fits_uncompress_table` given this is not standard on all platforms and take input from a signed int.