### PR TITLE
Incorrect usage of getenv to read an integer value

### DIFF
--- a/drvrgsiftp.c
+++ b/drvrgsiftp.c
@@ -38,10 +38,9 @@ static void signal_handler(int sig);
 int gsiftp_init(void)
 {
 
-  if (getenv("GSIFTP_TMPFILE")) {
-    gsiftp_tmpfile = getenv("GSIFTP_TMPFILE");
-  } else {
+  if (!(gsiftp_tmpfile = getenv("GSIFTP_TMPFILE"))) {
     strncpy(gsiftp_tmpdir, "/tmp/gsiftp_XXXXXX", sizeof gsiftp_tmpdir);
+    gsiftp_tmpdir[sizeof gsiftp_tmpdir - 1] = '\0'; // Ensure NUL-termination of string
     if (mkdtemp(gsiftp_tmpdir) == NULL) {
         ffpmsg("Cannot create temporary directory!");
         return (FILE_NOT_OPENED);
@@ -92,7 +91,7 @@ int gsiftp_open(char *filename, int rwmode, int *handle)
   int num_streams;
 
   if (num_streams_str = getenv("GSIFTP_STREAMS")) {
-    num_streams = atoi(num_streams_str) || 1;
+    num_streams = atoi(num_streams_str);
     if (num_streams < 1) num_streams = 1;
   } else {
     num_streams = 1;
@@ -164,7 +163,7 @@ int gsiftp_flush(int handle)
   int num_streams;
 
   if (num_streams_str = getenv("GSIFTP_STREAMS")) {
-    num_streams = atoi(num_streams_str) || 1;
+    num_streams = atoi(num_streams_str);
     if (num_streams < 1) num_streams = 1;
   } else {
     num_streams = 1;

--- a/drvrgsiftp.c
+++ b/drvrgsiftp.c
@@ -88,10 +88,12 @@ int gsiftp_checkfile(char *urltype, char *infile, char *outfile)
 int gsiftp_open(char *filename, int rwmode, int *handle)
 {
   FILE *gsiftpfile;
+  char *num_streams_str;
   int num_streams;
 
-  if (getenv("GSIFTP_STREAMS")) {
-    num_streams = (int)getenv("GSIFTP_STREAMS");
+  if (num_streams_str = getenv("GSIFTP_STREAMS")) {
+    num_streams = atoi(num_streams_str) || 1;
+    if (num_streams < 1) num_streams = 1;
   } else {
     num_streams = 1;
   }
@@ -158,10 +160,12 @@ int gsiftp_size(int handle, LONGLONG *filesize)
 int gsiftp_flush(int handle)
 {
   FILE *gsiftpfile;
+  char *num_streams_str;
   int num_streams;
 
-  if (getenv("GSIFTP_STREAMS")) {
-    num_streams = (int)getenv("GSIFTP_STREAMS");
+  if (num_streams_str = getenv("GSIFTP_STREAMS")) {
+    num_streams = atoi(num_streams_str) || 1;
+    if (num_streams < 1) num_streams = 1;
   } else {
     num_streams = 1;
   }


### PR DESCRIPTION
Not very familiar with usage of `getenv` but from reading the docs, it looks like this fix is probably the intended usage.

