### PR TITLE
Clean up unused parameter warnings

### DIFF
--- a/drvrfile.c
+++ b/drvrfile.c
@@ -1038,8 +1038,8 @@ int stream_open(char *filename, int rwmode, int *handle)
     /*
         read from stdin
     */
-    if (filename)
-      rwmode = 1;  /* dummy statement to suppress unused parameter compiler warning */
+    (void)filename; /* suppress unused parameter compiler warning */   
+    (void)rwmode;  /* suppress unused parameter compiler warning */
 
     *handle = 1;     /*  1 = stdin */   
 
@@ -1052,10 +1052,8 @@ int stream_create(char *filename, int *handle)
         write to stdout
     */
 
-    if (filename)  /* dummy statement to suppress unused parameter compiler warning */
-       *handle = 2;
-    else
-       *handle = 2;         /*  2 = stdout */       
+    (void)filename; /* suppress unused parameter compiler warning */
+    *handle = 2;         /*  2 = stdout */       
 
     return(0);
 }
@@ -1065,7 +1063,7 @@ int stream_size(int handle, LONGLONG *filesize)
   return the size of the file in bytes
 */
 {
-    handle = 0;  /* suppress unused parameter compiler warning */
+    (void)handle;  /* suppress unused parameter compiler warning */
     
     /* this operation is not supported in a stream; return large value */
     *filesize = LONG_MAX;
@@ -1077,7 +1075,7 @@ int stream_close(int handle)
      don't have to close stdin or stdout 
 */
 {
-    handle = 0;  /* suppress unused parameter compiler warning */
+    (void)handle;  /* suppress unused parameter compiler warning */
     
     return(0);
 }
@@ -1098,7 +1096,8 @@ int stream_seek(int handle, LONGLONG offset)
       seeking is not allowed in a stream
    */
 {
-    offset = handle;  /* suppress unused parameter compiler warning */
+    (void)offset;  /* suppress unused parameter compiler warning */
+    (void)handle;  /* suppress unused parameter compiler warning */
     return(1);
 }
 /*--------------------------------------------------------------------------*/

--- a/drvrgsiftp.c
+++ b/drvrgsiftp.c
@@ -232,6 +232,8 @@ static void done_cb( void * 				user_arg,
                      globus_ftp_client_handle_t * 	handle,
                      globus_object_t * 			err)
 {
+    (void)user_arg; /* suppress unused parameter compiler warning */
+    (void)handle;   /* suppress unused parameter compiler warning */
 
     if(err){
         fprintf(stderr, "%s", globus_object_printable_to_string(err));
@@ -252,6 +254,8 @@ static void data_cb_read( void * 			user_arg,
                           globus_off_t 			offset,
                           globus_bool_t 		eof)
 {
+    (void)offset;  /* suppress unused parameter compiler warning */
+  
     if(err) {
         fprintf(stderr, "%s", globus_object_printable_to_string(err));
     }
@@ -283,6 +287,10 @@ static void data_cb_write( void * 			user_arg,
                            globus_bool_t 		eof)
 {
     int curr_offset;
+
+    (void)length; /* suppress unused parameter compiler warning */
+    (void)offset; /* suppress unused parameter compiler warning */
+
     if(err) {
         fprintf(stderr, "%s", globus_object_printable_to_string(err));
     }

--- a/drvrmem.c
+++ b/drvrmem.c
@@ -97,6 +97,8 @@ int mem_create(char *filename, int *handle)
 {
     int status;
 
+    (void)filename;  /* suppress unused parameter compiler warning */
+
     /* initially allocate 1 FITS block = 2880 bytes */
     status = mem_createmem(2880L, handle);
 
@@ -294,11 +296,12 @@ int stdin_checkfile(char *urltype, char *infile, char *outfile)
    do any special case checking when opening a file on the stdin stream
 */
 {
+    (void)infile;  /* suppress unused parameter compiler warning */
     if (strlen(outfile))
     {
         stdin_outfile[0] = '\0';
         strncat(stdin_outfile,outfile,FLEN_FILENAME-1); /* an output file is specified */
-	strcpy(urltype,"stdinfile://");
+        strcpy(urltype,"stdinfile://");
     }
     else
         *stdin_outfile = '\0';  /* no output file was specified */
@@ -559,6 +562,7 @@ int mem_compress_openrw(char *filename, int rwmode, int *hdl)
   the memory 'file' to be opened with READWRITE access.
 */
 {
+   (void)rwmode;  /* suppress unused parameter compiler warning */
    return(mem_compress_open(filename, READONLY, hdl));  
 }
 /*--------------------------------------------------------------------------*/
@@ -805,6 +809,8 @@ int mem_iraf_open(char *filename, int rwmode, int *hdl)
 {
     int status;
     size_t filesize = 0;
+
+    (void)rwmode;  /* suppress unused parameter compiler warning */
 
     /* create a memory file with size = 0 for the FITS converted IRAF file */
     status = mem_createmem(filesize, hdl);
@@ -1288,6 +1294,8 @@ void bzip2uncompress2mem(char *filename, FILE *diskfile, int hdl,
     char buf[8192];
     size_t total_read = 0;
     char* errormsg = NULL;
+
+    (void)filename;  /* suppress unused parameter compiler warning */
 
     *filesize = 0;
     *status = 0;

--- a/drvrnet.c
+++ b/drvrnet.c
@@ -1291,7 +1291,10 @@ int curlProgressCallback(void *clientp, double dltotal, double dlnow,
    char *urlname=0;
    static int isComplete = 0;
    static int isFirst = 1;
-   
+
+   (void)ultotal; /* suppress unused parameter compiler warning */
+   (void)ulnow;  /* suppress unused parameter compiler warning */
+
    /* isFirst is true the very first time this is entered. Afterwards it
       should get reset to true when isComplete is first detected to have 
       toggled from true to false. */
@@ -3704,6 +3707,9 @@ int http_checkfile (char *urltype, char *infile, char *outfile1)
 /*--------------------------------------------------------------------------*/
 int https_checkfile (char *urltype, char *infile, char *outfile1)
 {
+
+  (void)infile;  /* suppress unused parameter compiler warning */
+
   /* set default  */
   strcpy(urltype,"https://");
   
@@ -3728,6 +3734,9 @@ int https_checkfile (char *urltype, char *infile, char *outfile1)
 /*--------------------------------------------------------------------------*/
 int ftps_checkfile (char *urltype, char *infile, char *outfile1)
 {
+
+   (void)infile;  /* suppress unused parameter compiler warning */
+
    strcpy(urltype,"ftps://");
    if (strlen(outfile1))
    {

--- a/drvrsmem.c
+++ b/drvrsmem.c
@@ -803,7 +803,7 @@ int     smem_shutdown(void)
  }
 
 int     smem_setoptions(int option)
- { option = 0;
+ { (void)option; /* suppress unused parameter compiler warning */
    return(0);
  }
 

--- a/eval.l
+++ b/eval.l
@@ -480,6 +480,7 @@ int yywrap(yyscan_t scanner)
      pre-2.5.1 versions of flex which
      do not recognize %option noyywrap 
   */
+  (void)scanner; /* suppress unused parameter compiler warning */
   return(1);
 }
 

--- a/eval.y
+++ b/eval.y
@@ -6393,6 +6393,8 @@ static void yyerror(yyscan_t scanner, ParseData *lParse, char *s)
 {
     char msg[80];
 
+	(void)scanner; /* suppress unused parameter compiler warning */
+
     if( !lParse->status ) lParse->status = PARSE_SYNTAX_ERR;
 
     strncpy(msg, s, 80);

--- a/eval.y
+++ b/eval.y
@@ -5387,7 +5387,7 @@ static void Do_Deref( ParseData *lParse, Node *this )
 	       if( this->type==STRING )
 		 this->value.undef[row] = theVar->value.undef[row];
 	       else if( this->type==BITSTR ) 
-		 this->value.undef;  /* Dummy - BITSTRs do not have undefs */
+		 (void)this->value.undef;  /* Dummy - BITSTRs do not have undefs */
 	       else 
 		 this->value.undef[row] = theVar->value.undef[elem];
 
@@ -5481,7 +5481,7 @@ static void Do_Deref( ParseData *lParse, Node *this )
 	       if( this->type==STRING )
 		 this->value.undef[row] = theVar->value.undef[row];
 	       else if( this->type==BITSTR ) 
-		 this->value.undef;  /* Dummy - BITSTRs do not have undefs */
+		 (void)this->value.undef;  /* Dummy - BITSTRs do not have undefs */
 	       else 
 		 this->value.undef[row] = theVar->value.undef[elem];
 

--- a/eval_f.c
+++ b/eval_f.c
@@ -2254,6 +2254,11 @@ int ffffrw_work(long        totalrows, /* I - Total rows to be processed     */
     ffffrw_workdata *workData = userPtr;
     ParseData *lParse = workData->lParse;
 
+    (void)totalrows; /* suppress unused parameter compiler warning */
+    (void)offset;    /* suppress unused parameter compiler warning */
+    (void)nCols;     /* suppress unused parameter compiler warning */
+    (void)colData;   /* suppress unused parameter compiler warning */
+
     Evaluate_Parser( lParse, firstrow, nrows );
 
     if( !lParse->status ) {

--- a/eval_l.c
+++ b/eval_l.c
@@ -1,6 +1,6 @@
-#line 1 "eval_l.c"
+#line 2 "eval_l.c"
 
-#line 3 "eval_l.c"
+#line 4 "eval_l.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -922,8 +922,8 @@ static int expr_read( ParseData *lParse, char *buf, int nbytes );
         if ( (result = expr_read( yylParse, (char *) buf, max_size )) < 0 ) \
             YY_FATAL_ERROR( "read() in flex scanner failed" );
 
-#line 925 "eval_l.c"
 #line 926 "eval_l.c"
+#line 927 "eval_l.c"
 
 #define INITIAL 0
 
@@ -1200,7 +1200,7 @@ YY_DECL
 #line 158 "eval.l"
 
 
-#line 1203 "eval_l.c"
+#line 1204 "eval_l.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1691,7 +1691,7 @@ YY_RULE_SETUP
 #line 474 "eval.l"
 ECHO;
 	YY_BREAK
-#line 1694 "eval_l.c"
+#line 1695 "eval_l.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -2882,6 +2882,7 @@ int yywrap(yyscan_t scanner)
      pre-2.5.1 versions of flex which
      do not recognize %option noyywrap 
   */
+  (void)scanner; /* suppress unused parameter compiler warning */
   return(1);
 }
 

--- a/eval_y.c
+++ b/eval_y.c
@@ -8631,6 +8631,8 @@ static void yyerror(yyscan_t scanner, ParseData *lParse, char *s)
 {
     char msg[80];
 
+	(void)scanner; /* suppress unused parameter compiler warning */
+
     if( !lParse->status ) lParse->status = PARSE_SYNTAX_ERR;
 
     strncpy(msg, s, 80);

--- a/eval_y.c
+++ b/eval_y.c
@@ -7625,7 +7625,7 @@ static void Do_Deref( ParseData *lParse, Node *this )
 	       if( this->type==STRING )
 		 this->value.undef[row] = theVar->value.undef[row];
 	       else if( this->type==BITSTR ) 
-		 this->value.undef;  /* Dummy - BITSTRs do not have undefs */
+		 (void)this->value.undef;  /* Dummy - BITSTRs do not have undefs */
 	       else 
 		 this->value.undef[row] = theVar->value.undef[elem];
 
@@ -7719,7 +7719,7 @@ static void Do_Deref( ParseData *lParse, Node *this )
 	       if( this->type==STRING )
 		 this->value.undef[row] = theVar->value.undef[row];
 	       else if( this->type==BITSTR ) 
-		 this->value.undef;  /* Dummy - BITSTRs do not have undefs */
+		 (void)this->value.undef;  /* Dummy - BITSTRs do not have undefs */
 	       else 
 		 this->value.undef[row] = theVar->value.undef[elem];
 

--- a/f77_wrap1.c
+++ b/f77_wrap1.c
@@ -237,6 +237,8 @@ FCALLSCSUB3(Cffreopen,FTREOPEN,ftreopen,FITSUNIT,PFITSUNIT,PINT)
 void Cffinit( fitsfile **fptr, const char *filename, int blocksize, int *status );
 void Cffinit( fitsfile **fptr, const char *filename, int blocksize, int *status )
 {
+   (void)blocksize;  /* suppress unused parameter compiler warning */
+
    if( *fptr==NULL || *fptr==(fitsfile*)1 ) {
       ffinit( fptr, filename, status );
    } else {
@@ -249,6 +251,8 @@ FCALLSCSUB4(Cffinit,FTINIT,ftinit,PFITSUNIT,STRING,INT,PINT)
 void Cffdkinit( fitsfile **fptr, const char *filename, int blocksize, int *status );
 void Cffdkinit( fitsfile **fptr, const char *filename, int blocksize, int *status )
 {
+   (void)blocksize;  /* suppress unused parameter compiler warning */
+
    if( *fptr==NULL || *fptr==(fitsfile*)1 ) {
       ffdkinit( fptr, filename, status );
    } else {

--- a/fitscore.c
+++ b/fitscore.c
@@ -2493,6 +2493,8 @@ then values of 'n' less than or equal to n_value will match.
     int ip, ic, pat, pass = 0, firstfail;
     char *spat;
 
+    (void)naxis; /* suppress unused parameter compiler warning */
+
     if (*status > 0)
         return(*status);
 

--- a/histo.c
+++ b/histo.c
@@ -3028,6 +3028,12 @@ int ffwritehisto(long totaln, long pixoffset, long firstn, long nvalues,
     long rows_per_loop = 0, offset = 0;
     histType *histData;
 
+    (void)totaln; /* suppress unused parameter compiler warning */
+    (void)pixoffset; /* suppress unused parameter compiler warning */
+    (void)firstn; /* suppress unused parameter compiler warning */
+    (void)nvalues; /* suppress unused parameter compiler warning */
+    (void)narrays; /* suppress unused parameter compiler warning */
+
     histData = (histType *)userPointer;
 
     /* store pointer to the histogram array, and initialize to zero */
@@ -3075,6 +3081,9 @@ int ffcalchist(long totalrows, long offset, long firstrow, long nrows,
     double *colptr[MAXDIMS] = {0};
     int status = 0;
     long irow;
+
+    (void)ncols; /* suppress unused parameter compiler warning */
+    (void)colpars; /* suppress unused parameter compiler warning */
 
     if (firstrow == 1) {
       histData->rowselector_cur = histData->rowselector;

--- a/imcompress.c
+++ b/imcompress.c
@@ -229,6 +229,9 @@ int fits_init_randoms(void) {
 /*--------------------------------------------------------------------------*/
 void bz_internal_error(int errcode)
 {
+
+    (void)errcode; /* suppress unused parameter compiler warning */
+
     /* external function declared by the bzip2 code in bzlib_private.h */
     ffpmsg("bzip2 returned an internal error");
     ffpmsg("This should never happen");
@@ -2235,6 +2238,9 @@ int imcomp_write_nocompress_tile(fitsfile *outfptr,
 {
     char coltype[4];
 
+    (void)nullcheck; /* suppress unused parameter compiler warning */
+    (void)nullflagval; /* suppress unused parameter compiler warning */
+
     /* Write the uncompressed image tile pixels to the tile-compressed image file. */
     /* This is a special case when using NOCOMPRESS for diagnostic purposes in fpack. */ 
     /* Currently, this only supports a limited number of data types and */
@@ -2487,6 +2493,7 @@ int imcomp_convert_tile_tint(
     int flagval, *idata;
     long ii;
     
+    (void) outfptr;  /* suppress unused parameter compiler warning */
  
         /* datatype of input array is int.  We only support writing this datatype
            to a FITS image with BITPIX = 32 and with BZERO = 0 and BSCALE = 1.  */
@@ -2536,6 +2543,8 @@ int imcomp_convert_tile_tuint(
     int *idata;
     unsigned int *uintbuff, uintflagval;
     long ii;
+
+    (void) outfptr;  /* suppress unused parameter compiler warning */
  
        /* datatype of input array is unsigned int.  We only support writing this datatype
           to a FITS image with BITPIX = 32 and with BZERO = 0 and BSCALE = 2147483648.  */
@@ -7301,6 +7310,9 @@ int imcomp_merge_overlap (
     long tilepix, imgpix, tilepixbyte, imgpixbyte;
     int ii, overlap_bytes, overlap_flags;
 
+    (void)bnullarray; /* suppress unused parameter compiler warning */
+    (void)nullcheck; /* suppress unused parameter compiler warning */
+
     if (*status > 0)
         return(*status);
 
@@ -7514,6 +7526,8 @@ static int unquantize_i1r4(long row, /* tile number = row number in table  */
     long ii;
     int nextrand, iseed;
 
+    (void)dither_method; /* suppress unused parameter compiler warning */
+
     if (!fits_rand_value) 
        if (fits_init_randoms()) return(MEMORY_ALLOCATION);
 
@@ -7595,6 +7609,8 @@ static int unquantize_i2r4(long row, /* seed for random values  */
 {
     long ii;
     int nextrand, iseed;
+
+    (void)dither_method; /* suppress unused parameter compiler warning */
 
     if (!fits_rand_value) 
        if (fits_init_randoms()) return(MEMORY_ALLOCATION);
@@ -7756,6 +7772,8 @@ static int unquantize_i1r8(long row, /* tile number = row number in table  */
     long ii;
     int nextrand, iseed;
 
+    (void)dither_method; /* suppress unused parameter compiler warning */
+
     if (!fits_rand_value) 
        if (fits_init_randoms()) return(MEMORY_ALLOCATION);
 
@@ -7837,6 +7855,8 @@ static int unquantize_i2r8(long row, /* tile number = row number in table  */
 {
     long ii;
     int nextrand, iseed;
+
+    (void)dither_method; /* suppress unused parameter compiler warning */
 
     if (!fits_rand_value) 
        if (fits_init_randoms()) return(MEMORY_ALLOCATION);

--- a/utilities/fitsverify.c
+++ b/utilities/fitsverify.c
@@ -211,33 +211,43 @@ printf("    should be submitted to http://heasarc.gsfc.nasa.gov/cgi-bin/ftoolshe
 
 int PILGetFname(char *parname, char *filename)
 {
+  (void)parname;  /* suppress unused parameter compiler warning */
+  (void)filename;  /* suppress unused parameter compiler warning */
   return(0);
 }
 
 int PILGetString(char *parname, char *stringname)
 {
+  (void)parname;  /* suppress unused parameter compiler warning */
+  (void)stringname;  /* suppress unused parameter compiler warning */
   return(0);
 }
 
 int PILGetBool(char *parname, int *intvalue)
 {
+  (void)parname;  /* suppress unused parameter compiler warning */
+  (void)intvalue;  /* suppress unused parameter compiler warning */
   return(0);
 }
 
 int PILPutInt(char *parname, int intvalue)
 {
+  (void)parname;  /* suppress unused parameter compiler warning */
+  (void)intvalue;  /* suppress unused parameter compiler warning */
   return(0);
 }
 
 void set_toolname(char *taskname);
 void set_toolname(char *taskname)
 {
+  (void)taskname;  /* suppress unused parameter compiler warning */
   return;
 }
 
 void set_toolversion(char *taskname);
 void set_toolversion(char *taskname)
 {
+  (void)taskname;  /* suppress unused parameter compiler warning */
   return;
 }
 
@@ -258,10 +268,13 @@ void get_toolversion(char *taskvers)
 void headas_clobberfile(char *filename);
 void headas_clobberfile(char *filename)
 {
+  (void)filename;  /* suppress unused parameter compiler warning */
   return;
 }
 void HD_ERROR_THROW(char msg[256], int status);
 void HD_ERROR_THROW(char msg[256], int status)
 {
+  (void)msg;  /* suppress unused parameter compiler warning */
+  (void)status;  /* suppress unused parameter compiler warning */
   return;
 }

--- a/utilities/fpackutil.c
+++ b/utilities/fpackutil.c
@@ -1634,6 +1634,8 @@ int fp_unpack_hdu (fitsfile *infptr, fitsfile *outfptr, fpstate fpvar, int *stat
 {
 	int hdutype, lval;
 
+	(void)fpvar; /* suppress unused parameter compiler warning */
+
         if (*status > 0) return(0);
 
 	fits_get_hdu_type (infptr, &hdutype, status);
@@ -1969,6 +1971,9 @@ int fp_test_table (fitsfile *infptr, fitsfile *outfptr, fitsfile *outfptr2,
         char fzalgor[FLEN_VALUE];
 	LONGLONG headstart, datastart, dataend;
 	float elapse, cpu;
+
+	(void)outfptr2;  /* suppress unused parameter compiler warning */
+	(void)fpvar;     /* suppress unused parameter compiler warning */
 
 	if (*status) return(0);
 
@@ -2416,6 +2421,8 @@ int fp_i4rescale(fitsfile *infptr, int naxis, long *naxes, double rescale,
  */
 void abort_fpack(int sig)
 {
+      (void)sig; /* suppress unused parameter compiler warning */
+
      /* clean up by deleting temporary files */
      
       if (tempfilename[0]) {

--- a/utilities/ftverify.c
+++ b/utilities/ftverify.c
@@ -273,6 +273,11 @@ int ftverify_work(
     int i, nerrs, nwarns;
     char msg[MAXMSG];
 
+    (void)prehead;  /* suppress unused parameter compiler warning */
+    (void)testdata;  /* suppress unused parameter compiler warning */
+    (void)testcsum;  /* suppress unused parameter compiler warning */
+    (void)testfill;  /* suppress unused parameter compiler warning */
+
     /* determine 'Severe error", "Error", or "Warning" report level */
     if( *errreport == 's' || *errreport == 'S') err_report = 2;
     if( *errreport == 'e' || *errreport == 'E') err_report = 1;

--- a/utilities/fvrf_data.c
+++ b/utilities/fvrf_data.c
@@ -547,6 +547,8 @@ data_end:
     long j,k,l;
     long nelem;
 
+    (void)offset; /* suppress unused parameter compiler warning */
+
     if(firstn == 1 ) {  /* first time for this table, so initialize */
         usrpt = (UserIter *)usrdata;
 /*

--- a/utilities/fvrf_file.c
+++ b/utilities/fvrf_file.c
@@ -247,6 +247,8 @@ void init_report(FILE *out,              /* output file */
                  char *rootnam          /* input file name */
                  )
 {
+    (void)rootnam; /* suppress unused parameter compiler warning */
+
     sprintf(comm,"\n%d Header-Data Units in this file.",totalhdu);
     wrtout(out,comm);
     wrtout(out," ");

--- a/utilities/fvrf_head.c
+++ b/utilities/fvrf_head.c
@@ -1246,6 +1246,8 @@ void test_ext(fitsfile *infits, 	/* input fits file   */
     int hdunum;
     char *p;
 
+    (void)infits; /* suppress unused parameter compiler warning */
+
     numusrkey = hduptr->tkeys;
     kwds = hduptr->kwds;
     hdunum = hduptr->hdunum;
@@ -1392,6 +1394,8 @@ void test_array(fitsfile *infits, 	/* input fits file   */
     char *p;
     int i,j,k,n;
     FitsKey *pkey;
+
+    (void)infits; /* suppress unused parameter compiler warning */
 
     /* excluded non-indexed keywords  */
     char *exlkeys[] = {"TFIELDS","THEAP"}; 
@@ -1619,6 +1623,8 @@ void test_tbl(fitsfile *infits, 	/* input fits file   */
     long w,d,e;
     long lm;
     int mcol;
+
+    (void)infits; /* suppress unused parameter compiler warning */
 
     /* excluded, non-index keywords (allowed in tile-compressed images) */
     char*  exlkey[] = {"BSCALE","BZERO", "BUNIT", "BLANK", "DATAMAX",
@@ -2524,6 +2530,8 @@ void test_header(
     int yy;
 
     kwdtyp ktype;
+
+    (void)infits; /* suppress unused parameter compiler warning */
     
     kwds = hduptr->kwds;
     numusrkey = hduptr->tkeys;
@@ -2967,6 +2975,8 @@ void   parse_vtform(fitsfile *infits,
     int i = 0; 
     int status = 0;
     char *p;
+
+    (void)hduptr; /* suppress unused parameter compiler warning */
     
 
     *maxlen = -1;
@@ -3133,6 +3143,8 @@ void print_summary(fitsfile *infits, 	/* input fits file   */
     char extnv[2*FLEN_VALUE+4];
     long npix;
     int hdutype;
+
+    (void)infits; /* suppress unused parameter compiler warning */
 
     /* get the error number and wrn number */ 
     set_hduerr(hduptr->hdunum);

--- a/zcompress.c
+++ b/zcompress.c
@@ -77,6 +77,7 @@ int uncompress2mem(char *filename,  /* name of input file                 */
     uLong iPage=0;
     uInt outbuffsize = (nPages > 0) ? UINT_MAX : (uInt)(*buffsize);
     
+    (void)filename;  /* suppress unused parameter compiler warning */
 
     if (*status > 0) 
         return(*status); 
@@ -271,6 +272,8 @@ int uncompress2file(char *filename,  /* name of input file                  */
     unsigned long bytes_out = 0;
     char *infilebuff, *outfilebuff;
     z_stream d_stream;   /* decompression stream */
+
+    (void)filename;  /* suppress unused parameter compiler warning */
 
     if (*status > 0) 
         return(*status); 


### PR DESCRIPTION
Supressed all warnings due to unused function parameters and unused values. Skip the fortran related code as it has some funky macros.

```bash
export CC=clang
export CFLAGS="-g -O0 -fPIC -Werror=unused-parameter -Werror=unused-but-set-parameter -Werror=unused-value -I/usr/include/globus -I/usr/include"
./configure --without-fortran --enable-reentrant --enable-sse2 --enable-ssse3 --enable-symbols --with-gsiftp --with-bzip2
make
```

