### PR TITLE
Fix warning about missing parentheses

### DIFF
--- a/drvrgsiftp.c
+++ b/drvrgsiftp.c
@@ -88,10 +88,10 @@ int gsiftp_checkfile(char *urltype, char *infile, char *outfile)
 int gsiftp_open(char *filename, int rwmode, int *handle)
 {
   FILE *gsiftpfile;
-  char *num_streams_str;
   int num_streams;
 
-  if (num_streams_str = getenv("GSIFTP_STREAMS")) {
+  char * num_streams_str = getenv("GSIFTP_STREAMS");
+  if (num_streams_str) {
     num_streams = atoi(num_streams_str);
     if (num_streams < 1) num_streams = 1;
   } else {
@@ -160,10 +160,10 @@ int gsiftp_size(int handle, LONGLONG *filesize)
 int gsiftp_flush(int handle)
 {
   FILE *gsiftpfile;
-  char *num_streams_str;
   int num_streams;
 
-  if (num_streams_str = getenv("GSIFTP_STREAMS")) {
+  char * num_streams_str = getenv("GSIFTP_STREAMS");
+  if (num_streams_str) {
     num_streams = atoi(num_streams_str);
     if (num_streams < 1) num_streams = 1;
   } else {


### PR DESCRIPTION
Additional parentheses should be added to indicate to the compiler that we are assigning instead of checking equality.

```bash
export CC=clang
export CFLAGS="-g -O0 -fPIC -Werror=parentheses -I/usr/include/globus -I/usr/include"
./configure --without-fortran --enable-reentrant --enable-sse2 --enable-ssse3 --enable-symbols --with-gsiftp --with-bzip2
make
```