### PR TITLE
Fix unitialized before used warnings

### DIFF
--- a/drvrnet.c
+++ b/drvrnet.c
@@ -4469,7 +4469,7 @@ static int encode64(unsigned s_len, char *src, unsigned d_len, char *dst) {
 
 
   for (triad = 0; triad < s_len; triad += 3) {
-    unsigned long int sr;
+    unsigned long int sr = 0;
     unsigned byte;
 
     for (byte = 0; (byte<3) && (triad+byte<s_len); ++byte) {

--- a/drvrsmem.c
+++ b/drvrsmem.c
@@ -394,7 +394,7 @@ static  long shared_adjust_size(long size)              /* size must be >= 0 !!!
 
 int     shared_malloc(long size, int mode, int newhandle)               /* return idx or SHARED_INVALID */
  { int h, i, r, idx, key;
-   union semun filler;
+   union semun filler = {0};
    BLKHEAD *bp;
    
    if (0 == shared_init_called)                 /* delayed initialization */


### PR DESCRIPTION
Fix warnings about using unitialized variables

```bash
export CC=clang
export CFLAGS="-g -O0 -fPIC -Werror=uninitialized -I/usr/include/globus -I/usr/include"
./configure --without-fortran --enable-reentrant --enable-sse2 --enable-ssse3 --enable-symbols --with-gsiftp --with-bzip2
make
```