### PR TITLE
cfitsio.pc.cmake: Support absolute install dirs

### DIFF
--- a/cfitsio.pc.cmake
+++ b/cfitsio.pc.cmake
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir="@CMAKE_INSTALL_FULL_LIBDIR@"
+includedir="@CMAKE_INSTALL_FULL_INCLUDEDIR@"
 
 Name: cfitsio
 Description: FITS File Subroutine Library


### PR DESCRIPTION
This allows `CMAKE_INSTALL_LIBDIR` and `CMAKE_INSTALL_INCLUDEDIR` to be either relative or absolute.

This is useful for distributions that use absolute paths, like `nixpkgs`, which currently need to patch `cfitsio.pc.cmake`.

### Example Relative Paths

```console
$ cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/tmp/cfitsio -DCMAKE_INSTALL_LIBDIR=lib123 -DCMAKE_INSTALL_INCLUDEDIR=headers
...
$ cat cfitsio.pc
libdir="/tmp/cfitsio/lib123"
includedir="/tmp/cfitsio/headers"

Name: cfitsio
Description: FITS File Subroutine Library
URL: https://heasarc.gsfc.nasa.gov/fitsio/
Version: 4.6.3
Libs: -L${libdir} -lcfitsio
Libs.private:  -lz -lcurl -lm
Cflags: -I${includedir}
```
### Example Absolute Paths

```console
$ cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/tmp/cfitsio -DCMAKE_INSTALL_LIBDIR=/tmp/cfitsio/lib123 -DCMAKE_INSTALL_INCLUDEDIR=/tmp/cfitsio/headers
...
$ cat cfitsio.pc
libdir="/tmp/cfitsio/lib123"
includedir="/tmp/cfitsio/headers"

Name: cfitsio
Description: FITS File Subroutine Library
URL: https://heasarc.gsfc.nasa.gov/fitsio/
Version: 4.6.3
Libs: -L${libdir} -lcfitsio
Libs.private:  -lz -lcurl -lm
Cflags: -I${includedir}
```