### PR TITLE
fix: lossless compression of unsigned and signed integer types uses wrong type translation

### DIFF
--- a/imcompress.c
+++ b/imcompress.c
@@ -6511,11 +6511,11 @@ int imcomp_decompress_tile (fitsfile *infptr,
 	 /* Just have to copy the values to the output array */
 	 
           if (tiledatatype == TINT) {
-              fffr4int((float *) idata, tilelen, bscale, bzero, nullcheck,   
+              fffi4int(idata, (long) tilelen, bscale, bzero, nullcheck, tnull,  
                 *(int *) nulval, bnullarray, anynul,
                 (int *) buffer, status);
           } else {
-              fffr8int((double *) idata, tilelen, bscale, bzero, nullcheck,   
+              fffi8int((LONGLONG *) idata, (long) tilelen, bscale, bzero, nullcheck, tnull,  
                 *(int *) nulval, bnullarray, anynul,
                 (int *) buffer, status);
           }

--- a/imcompress.c
+++ b/imcompress.c
@@ -6454,14 +6454,20 @@ int imcomp_decompress_tile (fitsfile *infptr,
         pixlen = sizeof(short);
 
 	if ((infptr->Fptr)->quantize_level == NO_QUANTIZE) {
-	 /* the floating point pixels were losselessly compressed with GZIP */
-	 /* Just have to copy the values to the output array */
-	 
+  	     /* Just have to copy the values to the output array */	 
           if (tiledatatype == TINT) {
               fffi4i2(idata, tilelen, bscale, bzero, nullcheck, tnull,  
                 *(short *) nulval, bnullarray, anynul,
                 (short *) buffer, status);
-          } else {
+	  	  } else if (tiledatatype == TSHORT) {
+		    fffi2i2((short *)idata, tilelen, bscale, bzero, nullcheck, (short) tnull,
+		       *(short *) nulval, bnullarray, anynul,
+		      (short *) buffer, status);
+		  } else if (tiledatatype == TBYTE) {
+		    fffi1i2((unsigned char *)idata, tilelen, bscale, bzero, nullcheck, (unsigned char) tnull,
+		       *(short *) nulval, bnullarray, anynul,
+		      (short *) buffer, status);
+		  } else {
               fffi8i2(idata, tilelen, bscale, bzero, nullcheck, tnull,  
                 *(short *) nulval, bnullarray, anynul,
                 (short *) buffer, status);

--- a/imcompress.c
+++ b/imcompress.c
@@ -6458,11 +6458,11 @@ int imcomp_decompress_tile (fitsfile *infptr,
 	 /* Just have to copy the values to the output array */
 	 
           if (tiledatatype == TINT) {
-              fffr4i2((float *) idata, tilelen, bscale, bzero, nullcheck,   
+              fffi4i2(idata, tilelen, bscale, bzero, nullcheck, tnull,  
                 *(short *) nulval, bnullarray, anynul,
                 (short *) buffer, status);
           } else {
-              fffr8i2((double *) idata, tilelen, bscale, bzero, nullcheck,   
+              fffi8i2(idata, tilelen, bscale, bzero, nullcheck, tnull,  
                 *(short *) nulval, bnullarray, anynul,
                 (short *) buffer, status);
           }

--- a/imcompress.c
+++ b/imcompress.c
@@ -6513,14 +6513,20 @@ int imcomp_decompress_tile (fitsfile *infptr,
         pixlen = sizeof(int);
 
 	if ((infptr->Fptr)->quantize_level == NO_QUANTIZE) {
-	 /* the floating point pixels were losselessly compressed with GZIP */
-	 /* Just have to copy the values to the output array */
-	 
+	      /* Just have to copy the values to the output array */	 
           if (tiledatatype == TINT) {
               fffi4int(idata, (long) tilelen, bscale, bzero, nullcheck, tnull,  
                 *(int *) nulval, bnullarray, anynul,
                 (int *) buffer, status);
-          } else {
+          } else if (tiledatatype == TSHORT) {
+              fffi2int((short *)idata, tilelen, bscale, bzero, nullcheck, (short) tnull,
+                *(int *) nulval, bnullarray, anynul,
+                (int *) buffer, status);
+		  } else if (tiledatatype == TBYTE) {
+              fffi1int((unsigned char *)idata, tilelen, bscale, bzero, nullcheck, (unsigned char) tnull,
+                *(int *) nulval, bnullarray, anynul,
+                (int *) buffer, status);
+		  } else {
               fffi8int((LONGLONG *) idata, (long) tilelen, bscale, bzero, nullcheck, tnull,  
                 *(int *) nulval, bnullarray, anynul,
                 (int *) buffer, status);
@@ -6551,15 +6557,21 @@ int imcomp_decompress_tile (fitsfile *infptr,
         pixlen = sizeof(long);
 
 	if ((infptr->Fptr)->quantize_level == NO_QUANTIZE) {
-	 /* the floating point pixels were losselessly compressed with GZIP */
-	 /* Just have to copy the values to the output array */
-	 
+  	     /* Just have to copy the values to the output array */	 
           if (tiledatatype == TINT) {
-              fffr4i4((float *) idata, tilelen, bscale, bzero, nullcheck,   
+              fffi4i4(idata, tilelen, bscale, bzero, nullcheck, tnull,  
                 *(long *) nulval, bnullarray, anynul,
                 (long *) buffer, status);
-          } else {
-              fffr8i4((double *) idata, tilelen, bscale, bzero, nullcheck,   
+	  	  } else if (tiledatatype == TSHORT) {
+		    fffi2i4((short *)idata, tilelen, bscale, bzero, nullcheck, (short) tnull,
+		       *(long *) nulval, bnullarray, anynul,
+		      (long *) buffer, status);
+		  } else if (tiledatatype == TBYTE) {
+		    fffi1i4((unsigned char *)idata, tilelen, bscale, bzero, nullcheck, (unsigned char) tnull,
+		       *(long *) nulval, bnullarray, anynul,
+		      (long *) buffer, status);
+		  } else {
+              fffi8i4(idata, tilelen, bscale, bzero, nullcheck, tnull,  
                 *(long *) nulval, bnullarray, anynul,
                 (long *) buffer, status);
           }
@@ -6752,19 +6764,25 @@ int imcomp_decompress_tile (fitsfile *infptr,
         pixlen = sizeof(short);
 
 	if ((infptr->Fptr)->quantize_level == NO_QUANTIZE) {
-	 /* the floating point pixels were losselessly compressed with GZIP */
-	 /* Just have to copy the values to the output array */
-	 
+  	     /* Just have to copy the values to the output array */	 
           if (tiledatatype == TINT) {
-              fffr4u2((float *) idata, tilelen, bscale, bzero, nullcheck,   
+              fffi4u2(idata, tilelen, bscale, bzero, nullcheck, tnull,  
                 *(unsigned short *) nulval, bnullarray, anynul,
                 (unsigned short *) buffer, status);
-          } else {
-              fffr8u2((double *) idata, tilelen, bscale, bzero, nullcheck,   
+	  	  } else if (tiledatatype == TSHORT) {
+		    fffi2u2((short *)idata, tilelen, bscale, bzero, nullcheck, (short) tnull,
+		       *(unsigned short *) nulval, bnullarray, anynul,
+		      (unsigned short *) buffer, status);
+		  } else if (tiledatatype == TBYTE) {
+		    fffi1u2((unsigned char *)idata, tilelen, bscale, bzero, nullcheck, (unsigned char) tnull,
+		       *(unsigned short *) nulval, bnullarray, anynul,
+		      (unsigned short *) buffer, status);
+		  } else {
+              fffi8u2(idata, tilelen, bscale, bzero, nullcheck, tnull,  
                 *(unsigned short *) nulval, bnullarray, anynul,
                 (unsigned short *) buffer, status);
           }
-        } else if (tiledatatype == TINT)
+	} else if (tiledatatype == TINT)
           if ((infptr->Fptr)->compress_type == PLIO_1 && actual_bzero == 32768.) {
 	    /* special case where unsigned 16-bit integers have been */
 	    /* offset by +32768 when using PLIO */
@@ -6790,15 +6808,21 @@ int imcomp_decompress_tile (fitsfile *infptr,
         pixlen = sizeof(int);
 
 	if ((infptr->Fptr)->quantize_level == NO_QUANTIZE) {
-	 /* the floating point pixels were losselessly compressed with GZIP */
-	 /* Just have to copy the values to the output array */
-	 
+  	     /* Just have to copy the values to the output array */	 
           if (tiledatatype == TINT) {
-              fffr4uint((float *) idata, tilelen, bscale, bzero, nullcheck,   
+              fffi4uint(idata, tilelen, bscale, bzero, nullcheck, tnull,  
                 *(unsigned int *) nulval, bnullarray, anynul,
                 (unsigned int *) buffer, status);
-          } else {
-              fffr8uint((double *) idata, tilelen, bscale, bzero, nullcheck,   
+	  	  } else if (tiledatatype == TSHORT) {
+		    fffi2uint((short *)idata, tilelen, bscale, bzero, nullcheck, (short) tnull,
+		       *(unsigned int *) nulval, bnullarray, anynul,
+		      (unsigned int *) buffer, status);
+		  } else if (tiledatatype == TBYTE) {
+		    fffi1uint((unsigned char *)idata, tilelen, bscale, bzero, nullcheck, (unsigned char) tnull,
+		       *(unsigned int *) nulval, bnullarray, anynul,
+		      (unsigned int *) buffer, status);
+		  } else {
+              fffi8uint(idata, tilelen, bscale, bzero, nullcheck, tnull,  
                 *(unsigned int *) nulval, bnullarray, anynul,
                 (unsigned int *) buffer, status);
           }
@@ -6829,19 +6853,25 @@ int imcomp_decompress_tile (fitsfile *infptr,
         pixlen = sizeof(long);
 
 	if ((infptr->Fptr)->quantize_level == NO_QUANTIZE) {
-	 /* the floating point pixels were losselessly compressed with GZIP */
-	 /* Just have to copy the values to the output array */
-	 
+  	     /* Just have to copy the values to the output array */	 
           if (tiledatatype == TINT) {
-              fffr4u4((float *) idata, tilelen, bscale, bzero, nullcheck,   
+              fffi4u4(idata, tilelen, bscale, bzero, nullcheck, tnull,  
                 *(unsigned long *) nulval, bnullarray, anynul,
                 (unsigned long *) buffer, status);
-          } else {
-              fffr8u4((double *) idata, tilelen, bscale, bzero, nullcheck,   
+	  	  } else if (tiledatatype == TSHORT) {
+		    fffi2u4((short *)idata, tilelen, bscale, bzero, nullcheck, (short) tnull,
+		       *(unsigned long *) nulval, bnullarray, anynul,
+		      (unsigned long *) buffer, status);
+		  } else if (tiledatatype == TBYTE) {
+		    fffi1u4((unsigned char *)idata, tilelen, bscale, bzero, nullcheck, (unsigned char) tnull,
+		       *(unsigned long *) nulval, bnullarray, anynul,
+		      (unsigned long *) buffer, status);
+		  } else {
+              fffi8u4(idata, tilelen, bscale, bzero, nullcheck, tnull,  
                 *(unsigned long *) nulval, bnullarray, anynul,
                 (unsigned long *) buffer, status);
           }
-        } else if (tiledatatype == TINT)
+	} else if (tiledatatype == TINT)
           if ((infptr->Fptr)->compress_type == PLIO_1 && actual_bzero == 32768.) {
 	    /* special case where unsigned 16-bit integers have been */
 	    /* offset by +32768 when using PLIO */

--- a/imcompress.c
+++ b/imcompress.c
@@ -6468,7 +6468,7 @@ int imcomp_decompress_tile (fitsfile *infptr,
 		       *(short *) nulval, bnullarray, anynul,
 		      (short *) buffer, status);
 		  } else {
-              fffi8i2(idata, tilelen, bscale, bzero, nullcheck, tnull,  
+              fffi8i2((LONGLONG *) idata, tilelen, bscale, bzero, nullcheck, tnull,  
                 *(short *) nulval, bnullarray, anynul,
                 (short *) buffer, status);
           }
@@ -6571,7 +6571,7 @@ int imcomp_decompress_tile (fitsfile *infptr,
 		       *(long *) nulval, bnullarray, anynul,
 		      (long *) buffer, status);
 		  } else {
-              fffi8i4(idata, tilelen, bscale, bzero, nullcheck, tnull,  
+              fffi8i4((LONGLONG *) idata, tilelen, bscale, bzero, nullcheck, tnull,  
                 *(long *) nulval, bnullarray, anynul,
                 (long *) buffer, status);
           }
@@ -6778,7 +6778,7 @@ int imcomp_decompress_tile (fitsfile *infptr,
 		       *(unsigned short *) nulval, bnullarray, anynul,
 		      (unsigned short *) buffer, status);
 		  } else {
-              fffi8u2(idata, tilelen, bscale, bzero, nullcheck, tnull,  
+              fffi8u2((LONGLONG *) idata, tilelen, bscale, bzero, nullcheck, tnull,  
                 *(unsigned short *) nulval, bnullarray, anynul,
                 (unsigned short *) buffer, status);
           }
@@ -6822,7 +6822,7 @@ int imcomp_decompress_tile (fitsfile *infptr,
 		       *(unsigned int *) nulval, bnullarray, anynul,
 		      (unsigned int *) buffer, status);
 		  } else {
-              fffi8uint(idata, tilelen, bscale, bzero, nullcheck, tnull,  
+              fffi8uint((LONGLONG *) idata, tilelen, bscale, bzero, nullcheck, tnull,  
                 *(unsigned int *) nulval, bnullarray, anynul,
                 (unsigned int *) buffer, status);
           }
@@ -6867,7 +6867,7 @@ int imcomp_decompress_tile (fitsfile *infptr,
 		       *(unsigned long *) nulval, bnullarray, anynul,
 		      (unsigned long *) buffer, status);
 		  } else {
-              fffi8u4(idata, tilelen, bscale, bzero, nullcheck, tnull,  
+              fffi8u4((LONGLONG *) idata, tilelen, bscale, bzero, nullcheck, tnull,  
                 *(unsigned long *) nulval, bnullarray, anynul,
                 (unsigned long *) buffer, status);
           }


### PR DESCRIPTION
Over in python fitsio land, we found a bug in lossless compression of integer types. TL;DR there appear to be some copy-paste errors in the translation of the uncompressed data back to the proper output type. You only hit the bug if you leave the FITS file open or use a `mem://` file, and even then it depends on how much of the file has been flushed out of the buffers.

See PR https://github.com/esheldon/fitsio/pull/453 for tests showing the patch works as expected.