### PR TITLE
Namespace internal stream_* functions

### DIFF
--- a/cfileio.c
+++ b/cfileio.c
@@ -5111,16 +5111,16 @@ int fits_init_cfitsio(void)
             NULL, 
             NULL,
 	    NULL,
-            stream_open,
-            stream_create,
+            fits_stream_open,
+            fits_stream_create,
             NULL,   /* no stream truncate function */
-            stream_close,
+            fits_stream_close,
             NULL,   /* no stream remove */
-            stream_size,
-            stream_flush,
-            stream_seek,
-            stream_read,
-            stream_write);
+            fits_stream_size,
+            fits_stream_flush,
+            fits_stream_seek,
+            fits_stream_read,
+            fits_stream_write);
 
     if (status)
     {

--- a/drvrfile.c
+++ b/drvrfile.c
@@ -1033,7 +1033,7 @@ int file_checkfile (char *urltype, char *infile, char *outfile)
 
 
 /*--------------------------------------------------------------------------*/
-int stream_open(char *filename, int rwmode, int *handle)
+int fits_stream_open(char *filename, int rwmode, int *handle)
 {
     /*
         read from stdin
@@ -1046,7 +1046,7 @@ int stream_open(char *filename, int rwmode, int *handle)
     return(0);
 }
 /*--------------------------------------------------------------------------*/
-int stream_create(char *filename, int *handle)
+int fits_stream_create(char *filename, int *handle)
 {
     /*
         write to stdout
@@ -1060,7 +1060,7 @@ int stream_create(char *filename, int *handle)
     return(0);
 }
 /*--------------------------------------------------------------------------*/
-int stream_size(int handle, LONGLONG *filesize)
+int fits_stream_size(int handle, LONGLONG *filesize)
 /*
   return the size of the file in bytes
 */
@@ -1072,7 +1072,7 @@ int stream_size(int handle, LONGLONG *filesize)
     return(0);
 }
 /*--------------------------------------------------------------------------*/
-int stream_close(int handle)
+int fits_stream_close(int handle)
 /*
      don't have to close stdin or stdout 
 */
@@ -1082,7 +1082,7 @@ int stream_close(int handle)
     return(0);
 }
 /*--------------------------------------------------------------------------*/
-int stream_flush(int handle)
+int fits_stream_flush(int handle)
 /*
   flush the file
 */
@@ -1093,7 +1093,7 @@ int stream_flush(int handle)
     return(0);
 }
 /*--------------------------------------------------------------------------*/
-int stream_seek(int handle, LONGLONG offset)
+int fits_stream_seek(int handle, LONGLONG offset)
    /* 
       seeking is not allowed in a stream
    */
@@ -1102,7 +1102,7 @@ int stream_seek(int handle, LONGLONG offset)
     return(1);
 }
 /*--------------------------------------------------------------------------*/
-int stream_read(int hdl, void *buffer, long nbytes)
+int fits_stream_read(int hdl, void *buffer, long nbytes)
 /*
      reading from stdin stream 
 */
@@ -1124,7 +1124,7 @@ int stream_read(int hdl, void *buffer, long nbytes)
     return(0);
 }
 /*--------------------------------------------------------------------------*/
-int stream_write(int hdl, void *buffer, long nbytes)
+int fits_stream_write(int hdl, void *buffer, long nbytes)
 /*
   write bytes at the current position in the file
 */

--- a/fitsio2.h
+++ b/fitsio2.h
@@ -1205,14 +1205,14 @@ int file_is_compressed(char *filename);
 
 /* stream driver I/O routines */
 
-int stream_open(char *filename, int rwmode, int *driverhandle);
-int stream_create(char *filename, int *driverhandle);
-int stream_size(int driverhandle, LONGLONG *filesize);
-int stream_close(int driverhandle);
-int stream_flush(int driverhandle);
-int stream_seek(int driverhandle, LONGLONG offset);
-int stream_read (int driverhandle, void *buffer, long nbytes);
-int stream_write(int driverhandle, void *buffer, long nbytes);
+int fits_stream_open(char *filename, int rwmode, int *driverhandle);
+int fits_stream_create(char *filename, int *driverhandle);
+int fits_stream_size(int driverhandle, LONGLONG *filesize);
+int fits_stream_close(int driverhandle);
+int fits_stream_flush(int driverhandle);
+int fits_stream_seek(int driverhandle, LONGLONG offset);
+int fits_stream_read (int driverhandle, void *buffer, long nbytes);
+int fits_stream_write(int driverhandle, void *buffer, long nbytes);
 
 /* memory driver I/O routines */
 


### PR DESCRIPTION
Although (from what I could gather) these are not part of the public API, and meant to be only internally used, they still end up as text symbols in the resulting shared libraries. On the other hand, these names are generic enough that other libraries might also export symbols with the same name (which again is sub-optimal, as they should also namespace _their_ functions). This clash of names leads to situations where, depending on whether libcfitsio and libAnotherLibrary was loaded first (or at all) into memory, the `stream_ function` of one library might be invoked instead of the other, usually leading to segmentation faults.

This commit renames the stream_* functions in libcfitsio to be prefixed with fits_. An alternative solution would be to hide these at link time, but that would require more widespread infrastructural changes.

Note that although similar issues might occur with other functions with generic names (e.g., "file_close", "mem_init" and so on), this commit focuses only on the problem at hand.