### PR TITLE
fix: more lossless compression bugs for ints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,5 @@ iter_b
 iter_c
 iter_image
 iter_var
+testf77
+testprog.fit

--- a/imcompress.c
+++ b/imcompress.c
@@ -6453,26 +6453,7 @@ int imcomp_decompress_tile (fitsfile *infptr,
     {
         pixlen = sizeof(short);
 
-	if ((infptr->Fptr)->quantize_level == NO_QUANTIZE) {
-  	     /* Just have to copy the values to the output array */	 
-          if (tiledatatype == TINT) {
-              fffi4i2(idata, tilelen, bscale, bzero, nullcheck, tnull,  
-                *(short *) nulval, bnullarray, anynul,
-                (short *) buffer, status);
-	  	  } else if (tiledatatype == TSHORT) {
-		    fffi2i2((short *)idata, tilelen, bscale, bzero, nullcheck, (short) tnull,
-		       *(short *) nulval, bnullarray, anynul,
-		      (short *) buffer, status);
-		  } else if (tiledatatype == TBYTE) {
-		    fffi1i2((unsigned char *)idata, tilelen, bscale, bzero, nullcheck, (unsigned char) tnull,
-		       *(short *) nulval, bnullarray, anynul,
-		      (short *) buffer, status);
-		  } else {
-              fffi8i2((LONGLONG *) idata, tilelen, bscale, bzero, nullcheck, tnull,  
-                *(short *) nulval, bnullarray, anynul,
-                (short *) buffer, status);
-          }
-        } else if (tiledatatype == TINT) {
+        if (tiledatatype == TINT) {
           if ((infptr->Fptr)->compress_type == PLIO_1 && actual_bzero == 32768.) {
 	    /* special case where unsigned 16-bit integers have been */
 	    /* offset by +32768 when using PLIO */
@@ -6506,32 +6487,17 @@ int imcomp_decompress_tile (fitsfile *infptr,
           fffi1i2((unsigned char *)idata, tilelen, bscale, bzero, nullcheck, (unsigned char) tnull,
            *(short *) nulval, bnullarray, anynul,
           (short *) buffer, status);
+        } else {
+          fffi8i2((LONGLONG *) idata, tilelen, bscale, bzero, nullcheck, tnull,  
+           *(short *) nulval, bnullarray, anynul,
+           (short *) buffer, status);
         }
     }
     else if (datatype == TINT)
     {
         pixlen = sizeof(int);
 
-	if ((infptr->Fptr)->quantize_level == NO_QUANTIZE) {
-	      /* Just have to copy the values to the output array */	 
-          if (tiledatatype == TINT) {
-              fffi4int(idata, (long) tilelen, bscale, bzero, nullcheck, tnull,  
-                *(int *) nulval, bnullarray, anynul,
-                (int *) buffer, status);
-          } else if (tiledatatype == TSHORT) {
-              fffi2int((short *)idata, tilelen, bscale, bzero, nullcheck, (short) tnull,
-                *(int *) nulval, bnullarray, anynul,
-                (int *) buffer, status);
-		  } else if (tiledatatype == TBYTE) {
-              fffi1int((unsigned char *)idata, tilelen, bscale, bzero, nullcheck, (unsigned char) tnull,
-                *(int *) nulval, bnullarray, anynul,
-                (int *) buffer, status);
-		  } else {
-              fffi8int((LONGLONG *) idata, (long) tilelen, bscale, bzero, nullcheck, tnull,  
-                *(int *) nulval, bnullarray, anynul,
-                (int *) buffer, status);
-          }
-        } else if (tiledatatype == TINT)
+        if (tiledatatype == TINT)
           if ((infptr->Fptr)->compress_type == PLIO_1 && actual_bzero == 32768.) {
 	    /* special case where unsigned 16-bit integers have been */
 	    /* offset by +32768 when using PLIO */
@@ -6551,31 +6517,16 @@ int imcomp_decompress_tile (fitsfile *infptr,
           fffi1int((unsigned char *)idata, tilelen, bscale, bzero, nullcheck, (unsigned char) tnull,
            *(int *) nulval, bnullarray, anynul,
            (int *) buffer, status);
+         else
+          fffi8int((LONGLONG *) idata, (long) tilelen, bscale, bzero, nullcheck, tnull,  
+            *(int *) nulval, bnullarray, anynul,
+            (int *) buffer, status);
     }
     else if (datatype == TLONG)
     {
         pixlen = sizeof(long);
 
-	if ((infptr->Fptr)->quantize_level == NO_QUANTIZE) {
-  	     /* Just have to copy the values to the output array */	 
-          if (tiledatatype == TINT) {
-              fffi4i4(idata, tilelen, bscale, bzero, nullcheck, tnull,  
-                *(long *) nulval, bnullarray, anynul,
-                (long *) buffer, status);
-	  	  } else if (tiledatatype == TSHORT) {
-		    fffi2i4((short *)idata, tilelen, bscale, bzero, nullcheck, (short) tnull,
-		       *(long *) nulval, bnullarray, anynul,
-		      (long *) buffer, status);
-		  } else if (tiledatatype == TBYTE) {
-		    fffi1i4((unsigned char *)idata, tilelen, bscale, bzero, nullcheck, (unsigned char) tnull,
-		       *(long *) nulval, bnullarray, anynul,
-		      (long *) buffer, status);
-		  } else {
-              fffi8i4((LONGLONG *) idata, tilelen, bscale, bzero, nullcheck, tnull,  
-                *(long *) nulval, bnullarray, anynul,
-                (long *) buffer, status);
-          }
-        } else if (tiledatatype == TINT)
+        if (tiledatatype == TINT)
           if ((infptr->Fptr)->compress_type == PLIO_1 && actual_bzero == 32768.) {
 	    /* special case where unsigned 16-bit integers have been */
 	    /* offset by +32768 when using PLIO */
@@ -6595,6 +6546,11 @@ int imcomp_decompress_tile (fitsfile *infptr,
           fffi1i4((unsigned char *)idata, tilelen, bscale, bzero, nullcheck, (unsigned char) tnull,
            *(long *) nulval, bnullarray, anynul,
             (long *) buffer, status);
+        else
+          fffi8i4((LONGLONG *) idata, tilelen, bscale, bzero, nullcheck, tnull,  
+            *(long *) nulval, bnullarray, anynul,
+            (long *) buffer, status);
+
     }
     else if (datatype == TFLOAT)
     {
@@ -6763,26 +6719,7 @@ int imcomp_decompress_tile (fitsfile *infptr,
     {
         pixlen = sizeof(short);
 
-	if ((infptr->Fptr)->quantize_level == NO_QUANTIZE) {
-  	     /* Just have to copy the values to the output array */	 
-          if (tiledatatype == TINT) {
-              fffi4u2(idata, tilelen, bscale, bzero, nullcheck, tnull,  
-                *(unsigned short *) nulval, bnullarray, anynul,
-                (unsigned short *) buffer, status);
-	  	  } else if (tiledatatype == TSHORT) {
-		    fffi2u2((short *)idata, tilelen, bscale, bzero, nullcheck, (short) tnull,
-		       *(unsigned short *) nulval, bnullarray, anynul,
-		      (unsigned short *) buffer, status);
-		  } else if (tiledatatype == TBYTE) {
-		    fffi1u2((unsigned char *)idata, tilelen, bscale, bzero, nullcheck, (unsigned char) tnull,
-		       *(unsigned short *) nulval, bnullarray, anynul,
-		      (unsigned short *) buffer, status);
-		  } else {
-              fffi8u2((LONGLONG *) idata, tilelen, bscale, bzero, nullcheck, tnull,  
-                *(unsigned short *) nulval, bnullarray, anynul,
-                (unsigned short *) buffer, status);
-          }
-	} else if (tiledatatype == TINT)
+	    if (tiledatatype == TINT)
           if ((infptr->Fptr)->compress_type == PLIO_1 && actual_bzero == 32768.) {
 	    /* special case where unsigned 16-bit integers have been */
 	    /* offset by +32768 when using PLIO */
@@ -6802,32 +6739,16 @@ int imcomp_decompress_tile (fitsfile *infptr,
           fffi1u2((unsigned char *)idata, tilelen, bscale, bzero, nullcheck, (unsigned char) tnull,
            *(unsigned short *) nulval, bnullarray, anynul,
             (unsigned short *) buffer, status);
+        else
+          fffi8u2((LONGLONG *) idata, tilelen, bscale, bzero, nullcheck, tnull,  
+            *(unsigned short *) nulval, bnullarray, anynul,
+            (unsigned short *) buffer, status);
     }
     else if (datatype == TUINT)
     {
         pixlen = sizeof(int);
 
-	if ((infptr->Fptr)->quantize_level == NO_QUANTIZE) {
-  	     /* Just have to copy the values to the output array */	 
-          if (tiledatatype == TINT) {
-              fffi4uint(idata, tilelen, bscale, bzero, nullcheck, tnull,  
-                *(unsigned int *) nulval, bnullarray, anynul,
-                (unsigned int *) buffer, status);
-	  	  } else if (tiledatatype == TSHORT) {
-		    fffi2uint((short *)idata, tilelen, bscale, bzero, nullcheck, (short) tnull,
-		       *(unsigned int *) nulval, bnullarray, anynul,
-		      (unsigned int *) buffer, status);
-		  } else if (tiledatatype == TBYTE) {
-		    fffi1uint((unsigned char *)idata, tilelen, bscale, bzero, nullcheck, (unsigned char) tnull,
-		       *(unsigned int *) nulval, bnullarray, anynul,
-		      (unsigned int *) buffer, status);
-		  } else {
-              fffi8uint((LONGLONG *) idata, tilelen, bscale, bzero, nullcheck, tnull,  
-                *(unsigned int *) nulval, bnullarray, anynul,
-                (unsigned int *) buffer, status);
-          }
-        } else
-         if (tiledatatype == TINT)
+        if (tiledatatype == TINT)
           if ((infptr->Fptr)->compress_type == PLIO_1 && actual_bzero == 32768.) {
 	    /* special case where unsigned 16-bit integers have been */
 	    /* offset by +32768 when using PLIO */
@@ -6847,31 +6768,16 @@ int imcomp_decompress_tile (fitsfile *infptr,
           fffi1uint((unsigned char *)idata, tilelen, bscale, bzero, nullcheck, (unsigned char) tnull,
            *(unsigned int *) nulval, bnullarray, anynul,
             (unsigned int *) buffer, status);
+        else 
+          fffi8uint((LONGLONG *) idata, tilelen, bscale, bzero, nullcheck, tnull,  
+            *(unsigned int *) nulval, bnullarray, anynul,
+            (unsigned int *) buffer, status);
     }
     else if (datatype == TULONG)
     {
         pixlen = sizeof(long);
 
-	if ((infptr->Fptr)->quantize_level == NO_QUANTIZE) {
-  	     /* Just have to copy the values to the output array */	 
-          if (tiledatatype == TINT) {
-              fffi4u4(idata, tilelen, bscale, bzero, nullcheck, tnull,  
-                *(unsigned long *) nulval, bnullarray, anynul,
-                (unsigned long *) buffer, status);
-	  	  } else if (tiledatatype == TSHORT) {
-		    fffi2u4((short *)idata, tilelen, bscale, bzero, nullcheck, (short) tnull,
-		       *(unsigned long *) nulval, bnullarray, anynul,
-		      (unsigned long *) buffer, status);
-		  } else if (tiledatatype == TBYTE) {
-		    fffi1u4((unsigned char *)idata, tilelen, bscale, bzero, nullcheck, (unsigned char) tnull,
-		       *(unsigned long *) nulval, bnullarray, anynul,
-		      (unsigned long *) buffer, status);
-		  } else {
-              fffi8u4((LONGLONG *) idata, tilelen, bscale, bzero, nullcheck, tnull,  
-                *(unsigned long *) nulval, bnullarray, anynul,
-                (unsigned long *) buffer, status);
-          }
-	} else if (tiledatatype == TINT)
+	    if (tiledatatype == TINT)
           if ((infptr->Fptr)->compress_type == PLIO_1 && actual_bzero == 32768.) {
 	    /* special case where unsigned 16-bit integers have been */
 	    /* offset by +32768 when using PLIO */
@@ -6890,6 +6796,10 @@ int imcomp_decompress_tile (fitsfile *infptr,
         else if (tiledatatype == TBYTE)
           fffi1u4((unsigned char *)idata, tilelen, bscale, bzero, nullcheck, (unsigned char) tnull,
            *(unsigned long *) nulval, bnullarray, anynul, 
+            (unsigned long *) buffer, status);
+        else
+          fffi8u4((LONGLONG *) idata, tilelen, bscale, bzero, nullcheck, tnull,  
+            *(unsigned long *) nulval, bnullarray, anynul,
             (unsigned long *) buffer, status);
     }
     else


### PR DESCRIPTION
This PR is followup to #97. I found one additional bug when using PLIO. I went ahead and simplified the code per @c181gordon's suggestion in the previous PR.

An updated set of test cases is [here](https://github.com/beckermr/misc/tree/main/work/2025_10_11_cfitsio_gzip_lossless_bug) showing the new code works in all cases.

cc @c181gordon for viz!