### PR TITLE
fix: zero existing normally compressed data if overwriting with gzip compressed data

### DIFF
--- a/imcompress.c
+++ b/imcompress.c
@@ -2217,8 +2217,8 @@ int imcomp_compress_tile (fitsfile *outfptr,
         ffpclb(outfptr, (outfptr->Fptr)->cn_gzip_data, row, 1,
              gzip_nelem, (unsigned char *) cbuf, status);
 
-        /* we must zero out existing compressed data if it exists. */
-        /* otherwise on read this data is read ahead of the gzipped */
+        /* We must zero out existing compressed data if it exists. */
+        /* Otherwise on read this data is read ahead of the gzipped */
         /* data and will cause a bug. */
         LONGLONG _test_nelemll, _test_offset;
         ffgdesll(outfptr, (outfptr->Fptr)->cn_compressed, row, &_test_nelemll, &_test_offset, 

--- a/imcompress.c
+++ b/imcompress.c
@@ -2218,7 +2218,7 @@ int imcomp_compress_tile (fitsfile *outfptr,
              gzip_nelem, (unsigned char *) cbuf, status);
 
         /* We must zero out existing compressed data if it exists. */
-        /* Otherwise on read this data is read ahead of the gzipped */
+        /* Otherwise, on read this data is read ahead of the gzipped */
         /* data and will cause a bug. */
         LONGLONG _test_nelemll, _test_offset;
         ffgdesll(outfptr, (outfptr->Fptr)->cn_compressed, row, &_test_nelemll, &_test_offset, 

--- a/imcompress.c
+++ b/imcompress.c
@@ -2217,7 +2217,7 @@ int imcomp_compress_tile (fitsfile *outfptr,
         ffpclb(outfptr, (outfptr->Fptr)->cn_gzip_data, row, 1,
              gzip_nelem, (unsigned char *) cbuf, status);
 
-        /* we must zero out existing existing compressed data if it exists. */
+        /* we must zero out existing compressed data if it exists. */
         /* otherwise on read this data is read ahead of the gzipped */
         /* data and will cause a bug. */
         LONGLONG _test_nelemll, _test_offset;

--- a/imcompress.c
+++ b/imcompress.c
@@ -2217,6 +2217,17 @@ int imcomp_compress_tile (fitsfile *outfptr,
         ffpclb(outfptr, (outfptr->Fptr)->cn_gzip_data, row, 1,
              gzip_nelem, (unsigned char *) cbuf, status);
 
+        /* we must zero out existing existing compressed data if it exists. */
+        /* otherwise on read this data is read ahead of the gzipped */
+        /* data and will cause a bug. */
+        LONGLONG _test_nelemll, _test_offset;
+        ffgdesll(outfptr, (outfptr->Fptr)->cn_compressed, row, &_test_nelemll, &_test_offset, 
+            status);
+        if (_test_nelemll) {
+            ffpclb(outfptr, (outfptr->Fptr)->cn_compressed, row, 1,
+                0, NULL, status);
+        }
+
         free(cbuf);  /* finished with this buffer */
     }
 


### PR DESCRIPTION
This PR fixes an edge case where a lossily tile compressed image is overwritten with data, but the new data cannot be lossily compressed. In this case, the code writes gzip-compressed data to a separate column in the table. However, we have to zero out the existing data in the original column since on read, the data in the original column is used if it is found.

I do not have a C example program for this bug, but I think I can write one if folks need it.