### PR TITLE
implement the gamma() row filter function

### DIFF
--- a/eval_defs.h
+++ b/eval_defs.h
@@ -126,6 +126,7 @@ typedef enum {
                   sqrt_fct,
                   abs_fct,
                   atan2_fct,
+                  gamma_fct,
                   ceil_fct,
                   floor_fct,
                   round_fct,

--- a/eval_y.c
+++ b/eval_y.c
@@ -2497,6 +2497,8 @@ yyreduce:
 		     else if (FSTRCMP((yyvsp[-2].str),"ARCTAN(") == 0
 			      || FSTRCMP((yyvsp[-2].str),"ATAN(") == 0)
 			(yyval.Node) = New_Func(lParse,  0, atan_fct, 1, (yyvsp[-1].Node), 0, 0, 0, 0, 0, 0 );
+		     else if (FSTRCMP((yyvsp[-2].str),"GAMMA(") == 0)
+			(yyval.Node) = New_Func(lParse,  0, gamma_fct,  1, (yyvsp[-1].Node), 0, 0, 0, 0, 0, 0 );
 		     else if (FSTRCMP((yyvsp[-2].str),"SINH(") == 0)
 			(yyval.Node) = New_Func(lParse,  0, sinh_fct,  1, (yyvsp[-1].Node), 0, 0, 0, 0, 0, 0 );
 		     else if (FSTRCMP((yyvsp[-2].str),"COSH(") == 0)
@@ -5963,6 +5965,7 @@ static void Do_Func( ParseData *lParse, Node *this )
 
    if( allConst ) {
 
+      int signp ;
       switch( this->operation ) {
 
 	    /* Non-Trig single-argument functions */
@@ -6064,6 +6067,10 @@ static void Do_Func( ParseData *lParse, Node *this )
 	    break;
 	 case atan_fct:
 	    this->value.data.dbl = atan( pVals[0].data.dbl );
+	    break;
+	 case gamma_fct:
+	    this->value.data.dbl = lgamma_r( pVals[0].data.dbl, & signp );
+	    this->value.data.dbl = exp(this->value.data.dbl)*signp ;
 	    break;
 	 case sinh_fct:
 	    this->value.data.dbl = sinh( pVals[0].data.dbl );
@@ -6880,6 +6887,15 @@ static void Do_Func( ParseData *lParse, Node *this )
 		     this->value.undef[elem] = 1;
 		  } else
 		     this->value.data.dblptr[elem] = log( dval );
+	       }
+	    break;
+	 case gamma_fct:
+	    while( elem-- )
+	       if( !(this->value.undef[elem] = theParams[0]->value.undef[elem]) ) {
+                  int signp ;
+		  dval = theParams[0]->value.data.dblptr[elem];
+                  this->value.data.dblptr[elem] = lgamma_r( dval,&signp );
+                  this->value.data.dblptr[elem] = signp*exp(this->value.data.dblptr[elem]) ;
 	       }
 	    break;
 	 case log10_fct:


### PR DESCRIPTION
Implements the ``gamma`` row filter functions requested in https://github.com/HEASARC/cfitsio/issues/85 . Has been tested with a ``fits_open_file(&fptr,"filt.fits[FILT][gamma(c)>5.9]",READWRITE,&status) ;`` code on a table with values from roughly 0.1 to 9.0 in a column named ``FILT`` and seems to work, which means the followup ``fits_get_num_rows(fptr,&nrows,&status ) ;`` seems to count only the rows with values in the range below roughly 0.15 and above roughly 4.

Well, apparently the compiler on the github repo is not compiling with the standard ``gcc`` definition set that come with my openSUSE 15.6 version, and ``configure.ac`` does nothing to test for _ISOC99_SOURCE or similar cpp macros explained in the lgamma(3) man page. This will also be a major headache to write an all-compatible ``erfc()`` or ``erf()``....

[I don't have a MAC here to test for workarounds on that platform.]