### PR TITLE
Stop writing RICE_ONE as an alias for RICE_1.

### DIFF
--- a/imcompress.c
+++ b/imcompress.c
@@ -1340,7 +1340,7 @@ int imcomp_init_table(fitsfile *outfptr,
               ffpky(outfptr, TINT, "ZDITHER0", &((outfptr->Fptr)->request_dither_seed), 
 	       "dithering offset when quantizing floats", status);
  
-            } else if ((outfptr->Fptr)->request_quantize_method == SUBTRACTIVE_DITHER_2) {
+        } else if ((outfptr->Fptr)->request_quantize_method == SUBTRACTIVE_DITHER_2) {
 	      ffpkys(outfptr, "ZQUANTIZ", "SUBTRACTIVE_DITHER_2", 
 	        "Pixel Quantization Algorithm", status);
 
@@ -1349,15 +1349,7 @@ int imcomp_init_table(fitsfile *outfptr,
               ffpky(outfptr, TINT, "ZDITHER0", &((outfptr->Fptr)->request_dither_seed), 
 	       "dithering offset when quantizing floats", status);
 
-	      if (!strcmp(zcmptype, "RICE_1"))  {
-	        /* when using this new dithering method, change the compression type */
-		/* to an alias, so that old versions of funpack will not be able to */
-		/* created a corrupted uncompressed image. */
-		/* ******* can remove this cludge after about June 2015, after most old versions of fpack are gone */
-        	strcpy(zcmptype, "RICE_ONE");
-	      }
-
-            } else if ((outfptr->Fptr)->request_quantize_method == NO_DITHER) {
+        } else if ((outfptr->Fptr)->request_quantize_method == NO_DITHER) {
 	      ffpkys(outfptr, "ZQUANTIZ", "NO_DITHER", 
 	        "No dithering during quantization", status);
 	    }


### PR DESCRIPTION
Code comments suggest that this was to be temporary workaround that should have been removed 10 years ago, but it was never standard-compliant.

Given how long CFITSIO has now been writing this key, it'd probably be appropriate to actually add it to the standard, but that's more scope than I have time for right now.