### PR TITLE
Reset quantize level on read and ensure NO_DITHER is default

### DIFF
--- a/imcompress.c
+++ b/imcompress.c
@@ -5314,24 +5314,32 @@ int imcomp_get_compressed_image_par(fitsfile *infptr, int *status)
     }
     else {
        /* get the floating point to integer quantization type, if present. */
-       /* FITS files produced before 2009 will not have this keyword */
+       /* FITS files produced before 2009 will not have this keyword. */
+       /* NO_DITHER should be treated as the default if it is not present. */
        tstatus = 0;
        if (ffgky(infptr, TSTRING, "ZQUANTIZ", value, NULL, &tstatus) > 0)
        {
            (infptr->Fptr)->quantize_method = 0;
            (infptr->Fptr)->quantize_level = 0;
        } else {
-
+           /* Note that we need to set quantize_level to something other than */
+           /* NO_QUANTIZE, since that would cause quantize_method to be ignored, */
+           /* and it might already be set from a different HDU. */
            if (!FSTRCMP(value, "NONE") ) {
                (infptr->Fptr)->quantize_level = NO_QUANTIZE;
-	  } else if (!FSTRCMP(value, "SUBTRACTIVE_DITHER_1") )
+	       } else if (!FSTRCMP(value, "SUBTRACTIVE_DITHER_1") ) {
                (infptr->Fptr)->quantize_method = SUBTRACTIVE_DITHER_1;
-           else if (!FSTRCMP(value, "SUBTRACTIVE_DITHER_2") )
+               (infptr->Fptr)->quantize_level = 0;
+           } else if (!FSTRCMP(value, "SUBTRACTIVE_DITHER_2") ) {
                (infptr->Fptr)->quantize_method = SUBTRACTIVE_DITHER_2;
-           else if (!FSTRCMP(value, "NO_DITHER") )
+               (infptr->Fptr)->quantize_level = 0;
+           } else if (!FSTRCMP(value, "NO_DITHER") ) {
                (infptr->Fptr)->quantize_method = NO_DITHER;
-           else
+               (infptr->Fptr)->quantize_level = 0;
+           } else {
                (infptr->Fptr)->quantize_method = 0;
+               (infptr->Fptr)->quantize_level = 0;
+           }
        }
     }
 

--- a/imcompress.c
+++ b/imcompress.c
@@ -5319,7 +5319,7 @@ int imcomp_get_compressed_image_par(fitsfile *infptr, int *status)
        tstatus = 0;
        if (ffgky(infptr, TSTRING, "ZQUANTIZ", value, NULL, &tstatus) > 0)
        {
-           (infptr->Fptr)->quantize_method = 0;
+           (infptr->Fptr)->quantize_method = NO_DITHER;
            (infptr->Fptr)->quantize_level = 0;
        } else {
            /* Note that we need to set quantize_level to something other than */

--- a/imcompress.c
+++ b/imcompress.c
@@ -5337,8 +5337,11 @@ int imcomp_get_compressed_image_par(fitsfile *infptr, int *status)
                (infptr->Fptr)->quantize_method = NO_DITHER;
                (infptr->Fptr)->quantize_level = 0;
            } else {
-               (infptr->Fptr)->quantize_method = 0;
-               (infptr->Fptr)->quantize_level = 0;
+               /* This is an invalid ZQUANTIZ key or an old CFITSIO */
+               /* encountering some future standard key. */
+               ffpmsg("Unknown quantization type:");
+               ffpmsg(value);
+	           return (*status = DATA_DECOMPRESSION_ERR);
            }
        }
     }


### PR DESCRIPTION
Of the three commits here (all touching the same ~20 line block), only the first is a clear bugfix, for a scenario in which ZZERO/ZSCALE are not applied after switching from an HDU with lossless compression to an HDU with quantized compression.
