### PR TITLE
Revert "fix: for floating point types do not treat underflowed floats differently when checking for nulls versus not"

### DIFF
--- a/getcold.c
+++ b/getcold.c
@@ -1418,7 +1418,7 @@ int fffr4r8(float *input,         /* I - array of values to be converted     */
                         nullarray[ii] = 1;
                   }
                   else            /* it's an underflow */
-                     output[ii] = (double) input[ii];
+                     output[ii] = 0;
               }
               else
                 output[ii] = (double) input[ii];
@@ -1439,7 +1439,7 @@ int fffr4r8(float *input,         /* I - array of values to be converted     */
                         nullarray[ii] = 1;
                   }
                   else            /* it's an underflow */
-                     output[ii] = input[ii] * scale + zero;
+                     output[ii] = zero;
               }
               else
                   output[ii] = input[ii] * scale + zero;
@@ -1519,7 +1519,7 @@ int fffr8r8(double *input,        /* I - array of values to be converted     */
                     }
                   }
                   else            /* it's an underflow */
-                     output[ii] = input[ii];
+                     output[ii] = 0;
               }
               else
                   output[ii] = input[ii];
@@ -1544,7 +1544,7 @@ int fffr8r8(double *input,        /* I - array of values to be converted     */
                     }
                   }
                   else            /* it's an underflow */
-                     output[ii] = input[ii] * scale + zero;
+                     output[ii] = zero;
               }
               else
                   output[ii] = input[ii] * scale + zero;

--- a/getcole.c
+++ b/getcole.c
@@ -1425,7 +1425,7 @@ int fffr4r4(float *input,         /* I - array of values to be converted     */
                     }
                   }
                   else            /* it's an underflow */
-                     output[ii] = input[ii];
+                     output[ii] = 0;
               }
               else
                 output[ii] = input[ii];
@@ -1450,7 +1450,7 @@ int fffr4r4(float *input,         /* I - array of values to be converted     */
                     }
                   }
                   else            /* it's an underflow */
-                     output[ii] = (float) (input[ii] * scale + zero);
+                     output[ii] = (float) zero;
               }
               else
                   output[ii] = (float) (input[ii] * scale + zero);
@@ -1549,8 +1549,8 @@ int fffr8r4(double *input,        /* I - array of values to be converted     */
                     else
                         nullarray[ii] = 1;
                   }
-                  else
-                    output[ii] = (float) input[ii];
+                  else            /* it's an underflow */
+                     output[ii] = 0;
               }
               else
               {
@@ -1596,7 +1596,7 @@ int fffr8r4(double *input,        /* I - array of values to be converted     */
                         output[ii] = FLT_MAX;
                      }
                      else
-                        output[ii] = (float) (input[ii] * scale + zero);
+                        output[ii] = (float) zero;
                    }
               }
               else


### PR DESCRIPTION
Reverts HEASARC/cfitsio#102

After performing the merge, I discovered that the original behavior -- different treatment of underflows depending on the setting of the NULLVAL parameter -- was intentional (see section 4.8 of the CFITSIO manual for handling of IEEE special values).  We should continue to allow the option of converting underflows to 0.0 for read image functions.