### PR TITLE
Add a system error message to file open errors

### DIFF
--- a/cfileio.c
+++ b/cfileio.c
@@ -805,8 +805,10 @@ int ffopen(fitsfile **fptr,      /* O - FITS file pointer                   */
         FFUNLOCK;
         if (*status > 0)
         {
-            ffpmsg("failed to find or open the following file: (ffopen)");
-            ffpmsg(url);
+            const char *err = strerror(errno);
+            char msg[512];
+            snprintf(msg, sizeof msg, "(ffopen) %s: %s", url, err);
+            ffpmsg(msg);
             return(*status);
        }
     }


### PR DESCRIPTION
The error message should unambiguously inform the user of the reason for an error rather than making the user guess.

This change provides the system error message so that messages of the form:

	failed to find or open the following file: (ffopen)
	tq123x.kjl

will instead be rendered in a single line as:

	(ffopen) tq123x.kjl: No such file or directory

or

	(ffopen) tq123x.kjl: Permission denied