### PR TITLE
Remove obsolete 'make shared' from docs

### DIFF
--- a/docs/cfitsio.tex
+++ b/docs/cfitsio.tex
@@ -275,7 +275,7 @@ The CFITSIO library is built on Unix systems by typing:
 \begin{verbatim}
  >  ./configure [--prefix=/target/installation/path] [--enable-reentrant]
                 [--enable-sse2] [--enable-ssse3]
- >  make          (or  'make shared')
+ >  make
  >  make install  (this step is optional)
 \end{verbatim}
 at the operating system prompt.  The configure command customizes the
@@ -320,12 +320,14 @@ externally compressed by the bzip2 algorithm.  This requires that the CFITSIO
 library, and all applications program that use CFITSIO, to be linked to include
 the libbz2 library.
 
-The 'make shared' option builds a shared or dynamic version of the
-CFITSIO library.  When using the shared library the executable code is
-not copied into your program at link time and instead the program
-locates the necessary library code at run time, normally through
-LD\_LIBRARY\_PATH or some other method. The advantages of using a shared
-library are:
+By default, both static and shared (dynamic) versions of the
+CFITSIO library are built.  To build only a static library, pass
+\verb+--disable-shared+ to configure; to build only a shared library,
+pass \verb+--disable-static+.  When using the shared library the
+executable code is not copied into your program at link time and
+instead the program locates the necessary library code at run time,
+normally through LD\_LIBRARY\_PATH or some other method.  The
+advantages of using a shared library are:
 
 \begin{verbatim}
    1.  Less disk space if you build more than 1 program
@@ -348,11 +350,10 @@ The disadvantages are:
       either really slow or really heavily loaded.
 \end{verbatim}
 
-On Mac OS X platforms the 'make shared' command works like on other
-UNIX platforms, but a .dylib file will be created instead of .so.  If
-installed in a nonstandard location, add its location to the
-DYLD\_LIBRARY\_PATH environment variable so that the library can be found
-at run time.
+On Mac OS X platforms, a .dylib file will be created instead of .so.
+If installed in a nonstandard location, add its location to the
+DYLD\_LIBRARY\_PATH environment variable so that the library can be
+found at run time.
 
 On HP/UX systems, the environment variable CFLAGS should be set
 to -Ae before running configure to enable "extended ANSI" features.


### PR DESCRIPTION
The 'make shared' target was removed in d575c98 when the build switched to Libtool.  Document the
--disable-shared and --disable-static configure flags instead.