### PR TITLE
Fix trivial semantic error

### DIFF
--- a/docs/cfitsio.tex
+++ b/docs/cfitsio.tex
@@ -422,7 +422,7 @@ On Unix systems, type:
 \end{verbatim}
 The test program should produce a FITS file called `testprog.fit'
 that is identical to the `testprog.std' FITS file included with this
-release.  The diagnostic messages (which were piped to the file
+release.  The diagnostic messages (which were redirected to the file
 testprog.lis in the Unix example) should be identical to the listing
 contained in the file testprog.out.  The 'diff' and 'cmp' commands
 shown above should not report any differences in the files.  (There


### PR DESCRIPTION
A pipe and a redirection are fundamentally different things; incorrectly referring to a redirection as a pipe contributes to ongoing confusion.
