### PR TITLE
build: fix CMake build when included as subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,7 +354,7 @@ IF (TESTS)
     ADD_TEST(TestProg TestProg)
     # Copy testprog.tpt to build directory to allow quick test
     # of ./TestProg (or .\Release\TestProg.exe in MSVC):
-    FILE(COPY ${CMAKE_SOURCE_DIR}/testprog.tpt DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+    FILE(COPY ${CMAKE_CURRENT_SOURCE_DIR}/testprog.tpt DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
     ADD_EXECUTABLE(cookbook utilities/cookbook.c)
     TARGET_LINK_LIBRARIES(cookbook ${LIB_NAME})


### PR DESCRIPTION
When including cfitsio as a subdirectory or use [CPM](https://github.com/cpm-cmake/CPM.cmake) for dependency management the following error is triggered during CMake configuration phase:

```
CMake Error at external/cfitsio/CMakeLists.txt:357 (FILE):
  FILE COPY cannot find "/home/xxx/myapp/cfitsio/testprog.tpt": No such file or directory.
```

Using CMAKE_CURRENT_SOURCE_DIR instead of CMAKE_SOURCE_DIR in line 357 fix it. 

CMake version: 4.2.1

Example app layout ([myapp.tar.gz](https://github.com/user-attachments/files/25728138/myapp.tar.gz)):

```
<dir>/
└── myapp/
    ├── external/
    │   └── cfitsio
    ├── myapp/
    │   ├── CMakeLists.txt
    │   └── myapp.c
    └── CMakeLists.txt
``` 