### PR TITLE
Add Dependabot to keep GitHub Action workflows up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Keep the GitHub Actions used in .github/workflows/* up to date
+# Reference: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"                  # Root of the repository
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10    # Prevent too many open PRs
+    labels:
+        - "dependabot"
+    # Group updates together (newer Dependabot feature)
+    groups:
+      actions:
+        dependency-type: "production"


### PR DESCRIPTION
This pull request adds a Dependabot GitHub Action to the repository. It will check all of the workflows under `.github/workflows/` for major version updates to the GitHub Actions referenced in those workflows and automatically open pull requests to update the workflows as necessary.

Automating dependency updates ensures that the repository's workflows stay current, reducing potential security vulnerabilities and technical debt without requiring periodic manual checks and manually creating pull requests.

Note: Once this is merged, maintainers can go to Insights > Dependency graph > Dependabot to see the results of the latest dependencies check.