### PR TITLE
replace dead link to wisc.edu by github in docs subdirectory

### DIFF
--- a/docs/cfitsio.tex
+++ b/docs/cfitsio.tex
@@ -7823,7 +7823,7 @@ There are two different ways to install GT:
 1) goto the globus toolkit web page www.globus.org and follow the
    download and compilation instructions;
 
-2) goto the Virtual Data Toolkit web page http://vdt.cs.wisc.edu/
+2) goto the Virtual Data Toolkit web page https://github.com/globus/globus-toolkit
    and follow the instructions (STRONGLY SUGGESTED);
 
 Once a globus client has been installed in your system with a specific flavour

--- a/docs/fitsio.tex
+++ b/docs/fitsio.tex
@@ -5260,7 +5260,7 @@ There are two different ways to install GT:
 1) goto the globus toolkit web page www.globus.org and follow the
    download and compilation instructions;
 
-2) goto the Virtual Data Toolkit web page http://vdt.cs.wisc.edu/
+2) goto the Virtual Data Toolkit web page https://github.com/globus/globus-toolkit
    and follow the instructions (STRONGLY SUGGESTED);
 
 Once a globus client has been installed in your system with a specific flavour


### PR DESCRIPTION
Closes https://github.com/heasarc/cfitsio/issues/109 by updating a dead link documented in the latex files.