### PR TITLE
Update fitscore to use _strtoui64 on windows

### DIFF
--- a/fitscore.c
+++ b/fitscore.c
@@ -9509,7 +9509,7 @@ int ffc2jj(const char *cval,  /* I - string representation of the value */
           LONGLONG *ival,     /* O - numerical value of the input string */
           int *status)        /* IO - error status */
 /*
-  convert null-terminated formatted string to an long long integer value
+  convert null-terminated formatted string to a long long integer value
 */
 {
     char *loc, msg[81];
@@ -9522,11 +9522,12 @@ int ffc2jj(const char *cval,  /* I - string representation of the value */
 
 #if defined(_MSC_VER)
 
-    /* Microsoft Visual C++ does not have the strtoull function, but it
-       provides _strtoui64, the unsigned 64-bit string conversion.  This
-       correctly handles values above LLONG_MAX (unlike _atoi64) and sets
-       errno to ERANGE on overflow. */
-    *ival = _strtoui64(cval, &loc, 10);
+    /* Microsoft Visual C++ does not have the strtoll function, but it
+       provides _strtoi64, the signed 64-bit string conversion.  Unlike
+       _atoi64 it reports the end of the parsed token (for the trailing-junk
+       check) and sets errno to ERANGE on overflow. */
+    *ival = _strtoi64(cval, &loc, 10);
+
 #elif (USE_LL_SUFFIX == 1)
     *ival = strtoll(cval, &loc, 10);  /* read the string as an integer */
 #else
@@ -9567,17 +9568,11 @@ int ffc2ujj(const char *cval,  /* I - string representation of the value */
 
 #if defined(_MSC_VER)
 
-    /* Microsoft Visual C++ 6.0 does not have the strtoll function */
-/*  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!  */
-/* !!!!!  This needs to be modified to use the unsigned long long version of _atoi64 */
-/*  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!  */
-
-    *ival =  _atoi64(cval);
-    loc = (char *) cval;
-    while (*loc == ' ') loc++;     /* skip spaces */
-    if    (*loc == '-') loc++;     /* skip minus sign */
-    if    (*loc == '+') loc++;     /* skip plus sign */
-    while (isdigit(*loc)) loc++;   /* skip digits */
+    /* Microsoft Visual C++ does not have the strtoull function, but it
+       provides _strtoui64, the unsigned 64-bit string conversion.  This
+       correctly handles values above LLONG_MAX (unlike _atoi64) and sets
+       errno to ERANGE on overflow. */
+    *ival = _strtoui64(cval, &loc, 10);
 
 #elif (USE_LL_SUFFIX == 1)
     *ival = strtoull(cval, &loc, 10);  /* read the string as an integer */

--- a/fitscore.c
+++ b/fitscore.c
@@ -9522,14 +9522,11 @@ int ffc2jj(const char *cval,  /* I - string representation of the value */
 
 #if defined(_MSC_VER)
 
-    /* Microsoft Visual C++ 6.0 does not have the strtoll function */
-    *ival =  _atoi64(cval);
-    loc = (char *) cval;
-    while (*loc == ' ') loc++;     /* skip spaces */
-    if    (*loc == '-') loc++;     /* skip minus sign */
-    if    (*loc == '+') loc++;     /* skip plus sign */
-    while (isdigit(*loc)) loc++;   /* skip digits */
-
+    /* Microsoft Visual C++ does not have the strtoull function, but it
+       provides _strtoui64, the unsigned 64-bit string conversion.  This
+       correctly handles values above LLONG_MAX (unlike _atoi64) and sets
+       errno to ERANGE on overflow. */
+    *ival = _strtoui64(cval, &loc, 10);
 #elif (USE_LL_SUFFIX == 1)
     *ival = strtoll(cval, &loc, 10);  /* read the string as an integer */
 #else


### PR DESCRIPTION
`_strtoui64` was available since MSVC 6.0 and looks like it is the logical choice. Shout if you think this is wrong.