### PR TITLE
Fix -Wunused-but-set-variable warnings

### DIFF
--- a/drvrnet.c
+++ b/drvrnet.c
@@ -2705,7 +2705,6 @@ int ftp_compress_open(char *url, int rwmode, int *handle)
 
 static int ftp_open_network(char *filename, FILE **ftpfile, FILE **command, int *sock)
 {
-  int status;
   int sock1;
   int tmpint;
   char recbuf[MAXLEN];
@@ -2798,7 +2797,7 @@ static int ftp_open_network(char *filename, FILE **ftpfile, FILE **command, int 
   /* Send the user name and wait for the right response */
   snprintf(tmpstr,MAXLEN,"USER %s\r\n",username);
 
-  status = NET_SendRaw(*sock,tmpstr,strlen(tmpstr),NET_DEFAULT);
+  NET_SendRaw(*sock,tmpstr,strlen(tmpstr),NET_DEFAULT);
 
   if (ftp_status(*command,"331 ")) {
     ffpmsg ("USER error no 331 seen (ftp_open_network)");
@@ -2809,7 +2808,7 @@ static int ftp_open_network(char *filename, FILE **ftpfile, FILE **command, int 
   
   /* Send the password and wait for the right response */
   snprintf(tmpstr,MAXLEN,"PASS %s\r\n",password);
-  status = NET_SendRaw(*sock,tmpstr,strlen(tmpstr),NET_DEFAULT);
+  NET_SendRaw(*sock,tmpstr,strlen(tmpstr),NET_DEFAULT);
   
   if (ftp_status(*command,"230 ")) {
     ffpmsg ("PASS error, no 230 seen (ftp_open_network)");
@@ -2838,7 +2837,7 @@ static int ftp_open_network(char *filename, FILE **ftpfile, FILE **command, int 
     }
   }
   
-  status = NET_SendRaw(*sock,tmpstr,strlen(tmpstr),NET_DEFAULT);
+  NET_SendRaw(*sock,tmpstr,strlen(tmpstr),NET_DEFAULT);
   
   if (ftp_status(*command,"250 ")) {
     ffpmsg ("CWD error, no 250 seen (ftp_open_network)");
@@ -2856,7 +2855,7 @@ static int ftp_open_network(char *filename, FILE **ftpfile, FILE **command, int 
 
   /* Always use binary mode */
   snprintf(tmpstr,MAXLEN,"TYPE I\r\n");
-  status = NET_SendRaw(*sock,tmpstr,strlen(tmpstr),NET_DEFAULT);
+  NET_SendRaw(*sock,tmpstr,strlen(tmpstr),NET_DEFAULT);
   
   if (ftp_status(*command,"200 ")) {
     ffpmsg ("TYPE I error, 200 not seen (ftp_open_network)");
@@ -2865,7 +2864,7 @@ static int ftp_open_network(char *filename, FILE **ftpfile, FILE **command, int 
     return (FILE_NOT_OPENED);
   }
  
-  status = NET_SendRaw(*sock,"PASV\r\n",6,NET_DEFAULT);
+  NET_SendRaw(*sock,"PASV\r\n",6,NET_DEFAULT);
 
   if (!(fgets(recbuf,MAXLEN,*command))) {
     ffpmsg ("PASV error (ftp_open)");
@@ -2964,7 +2963,7 @@ static int ftp_open_network(char *filename, FILE **ftpfile, FILE **command, int 
 
     /* Send the retrieve command */
     snprintf(tmpstr,MAXLEN,"RETR %s\r\n",newfn);
-    status = NET_SendRaw(*sock,tmpstr,strlen(tmpstr),NET_DEFAULT);
+    NET_SendRaw(*sock,tmpstr,strlen(tmpstr),NET_DEFAULT);
 
     if (ftp_status(*command,"150 ")) {
       fclose(*ftpfile);
@@ -4208,13 +4207,12 @@ int root_size(int handle, LONGLONG *filesize)
 
   int sock;
   int offset;
-  int status;
   int op;
 
   sock = handleTable[handle].sock;
 
-  status = root_send_buffer(sock,ROOTD_STAT,NULL,0);
-  status = root_recv_buffer(sock,&op,(char *)&offset, 4);
+  root_send_buffer(sock,ROOTD_STAT,NULL,0);
+  root_recv_buffer(sock,&op,(char *)&offset, 4);
   *filesize = (LONGLONG) ntohl(offset);
   
   return(0);
@@ -4226,11 +4224,10 @@ int root_close(int handle)
 */
 {
 
-  int status;
   int sock;
 
   sock = handleTable[handle].sock;
-  status = root_send_buffer(sock,ROOTD_CLOSE,NULL,0);
+  root_send_buffer(sock,ROOTD_CLOSE,NULL,0);
   close(sock);
   handleTable[handle].sock = 0;
   return(0);
@@ -4241,11 +4238,10 @@ int root_flush(int handle)
   flush the file
 */
 {
-  int status;
   int sock;
 
   sock = handleTable[handle].sock;
-  status = root_send_buffer(sock,ROOTD_FLUSH,NULL,0);
+  root_send_buffer(sock,ROOTD_FLUSH,NULL,0);
   return(0);
 }
 /*--------------------------------------------------------------------------*/

--- a/editcol.c
+++ b/editcol.c
@@ -1967,7 +1967,6 @@ int ffccls(fitsfile *infptr,    /* I - FITS file pointer to input file  */
     long tfields, repeat, orepeat, width, owidth;
     char keyname[FLEN_KEYWORD], ttype[FLEN_VALUE], tform[FLEN_VALUE];
     char ttype_comm[FLEN_COMMENT],tform_comm[FLEN_COMMENT];
-    int typecodes[1000];
     char *ttypes[1000], *tforms[1000], keyarr[1001][FLEN_CARD];
     int ikey = 0;
     int icol, incol1, outcol1;
@@ -2045,8 +2044,6 @@ int ffccls(fitsfile *infptr,    /* I - FITS file pointer to input file  */
 	  ffpmsg("Variable-length columns are not supported (ffccls)");
 	  return(*status = BAD_TFORM);
 	}
-
-      typecodes[icol] = typecode;
 
       tstatus = 0;
       ffkeyn("TTYPE", incol1, keyname, &tstatus);

--- a/eval.y
+++ b/eval.y
@@ -2563,7 +2563,6 @@ static void Do_Offset( ParseData *lParse, Node *this )
    Node *col;
    long fRow, nRowOverlap, nRowReload, rowOffset;
    long nelem, elem, offset, nRealElem;
-   int status;
 
    col       = lParse->Nodes + this->SubNodes[0];
    rowOffset = lParse->Nodes[  this->SubNodes[1] ].value.data.lng;
@@ -2658,22 +2657,22 @@ static void Do_Offset( ParseData *lParse, Node *this )
       switch( this->type ) {
       case BITSTR:
       case STRING:
-	 status = (*lParse->loadData)( lParse, -col->operation, fRow, nRowReload,
+	 (*lParse->loadData)( lParse, -col->operation, fRow, nRowReload,
 				      this->value.data.strptr+offset,
 				      this->value.undef+offset );
 	 break;
       case BOOLEAN:
-	 status = (*lParse->loadData)( lParse, -col->operation, fRow, nRowReload,
+	 (*lParse->loadData)( lParse, -col->operation, fRow, nRowReload,
 				      this->value.data.logptr+offset,
 				      this->value.undef+offset );
 	 break;
       case LONG:
-	 status = (*lParse->loadData)( lParse, -col->operation, fRow, nRowReload,
+	 (*lParse->loadData)( lParse, -col->operation, fRow, nRowReload,
 				      this->value.data.lngptr+offset,
 				      this->value.undef+offset );
 	 break;
       case DOUBLE:
-	 status = (*lParse->loadData)( lParse, -col->operation, fRow, nRowReload,
+	 (*lParse->loadData)( lParse, -col->operation, fRow, nRowReload,
 				      this->value.data.dblptr+offset,
 				      this->value.undef+offset );
 	 break;

--- a/eval_f.c
+++ b/eval_f.c
@@ -2724,7 +2724,6 @@ int fits_pixel_filter (PixelFilter * filter, int * status)
    long nelem, naxes[MAXDIMS];
    int col_cnt;
    Node *result;
-   int datatype;
    fitsfile * infptr;
    fitsfile * outfptr;
    char * DEFAULT_TAGS[] = { "X" };
@@ -2852,11 +2851,11 @@ int fits_pixel_filter (PixelFilter * filter, int * status)
    }
 
    switch (bitpix) {
-      case BYTE_IMG: datatype = TLONG; Info.datatype = TBYTE; break;
-      case SHORT_IMG: datatype = TLONG; Info.datatype = TSHORT; break;
-      case LONG_IMG: datatype = TLONG; Info.datatype = TLONG; break;
-      case FLOAT_IMG: datatype = TDOUBLE; Info.datatype = TFLOAT; break;
-      case DOUBLE_IMG: datatype = TDOUBLE; Info.datatype = TDOUBLE; break;
+      case BYTE_IMG: Info.datatype = TBYTE; break;
+      case SHORT_IMG: Info.datatype = TSHORT; break;
+      case LONG_IMG: Info.datatype = TLONG; break;
+      case FLOAT_IMG: Info.datatype = TFLOAT; break;
+      case DOUBLE_IMG: Info.datatype = TDOUBLE; break;
 
       default:
            snprintf(msg, 256,"pixel_filter: unexpected output bitpix %d\n", bitpix);

--- a/eval_y.c
+++ b/eval_y.c
@@ -4801,7 +4801,6 @@ static void Do_Offset( ParseData *lParse, Node *this )
    Node *col;
    long fRow, nRowOverlap, nRowReload, rowOffset;
    long nelem, elem, offset, nRealElem;
-   int status;
 
    col       = lParse->Nodes + this->SubNodes[0];
    rowOffset = lParse->Nodes[  this->SubNodes[1] ].value.data.lng;
@@ -4896,22 +4895,22 @@ static void Do_Offset( ParseData *lParse, Node *this )
       switch( this->type ) {
       case BITSTR:
       case STRING:
-	 status = (*lParse->loadData)( lParse, -col->operation, fRow, nRowReload,
+	 (*lParse->loadData)( lParse, -col->operation, fRow, nRowReload,
 				      this->value.data.strptr+offset,
 				      this->value.undef+offset );
 	 break;
       case BOOLEAN:
-	 status = (*lParse->loadData)( lParse, -col->operation, fRow, nRowReload,
+	 (*lParse->loadData)( lParse, -col->operation, fRow, nRowReload,
 				      this->value.data.logptr+offset,
 				      this->value.undef+offset );
 	 break;
       case LONG:
-	 status = (*lParse->loadData)( lParse, -col->operation, fRow, nRowReload,
+	 (*lParse->loadData)( lParse, -col->operation, fRow, nRowReload,
 				      this->value.data.lngptr+offset,
 				      this->value.undef+offset );
 	 break;
       case DOUBLE:
-	 status = (*lParse->loadData)( lParse, -col->operation, fRow, nRowReload,
+	 (*lParse->loadData)( lParse, -col->operation, fRow, nRowReload,
 				      this->value.data.dblptr+offset,
 				      this->value.undef+offset );
 	 break;

--- a/getcoluj.c
+++ b/getcoluj.c
@@ -2624,7 +2624,7 @@ int ffgclujj( fitsfile *fptr,   /* I - FITS file pointer                       *
     int tcode, maxelem2, hdutype, xcode, decimals;
     long twidth, incre;
     long ii, xwidth, ntodo;
-    int convert, nulcheck, readcheck = 0;
+    int nulcheck, readcheck = 0;
     LONGLONG repeat, startpos, elemnum, readptr, tnull;
     LONGLONG rowlen, rownum, remain, next, rowincre, maxelem;
     char tform[20];
@@ -2686,8 +2686,6 @@ int ffgclujj( fitsfile *fptr,   /* I - FITS file pointer                       *
 
     else if (tcode == TSTRING && snull[0] == ASCII_NULL_UNDEFINED)
          nulcheck = 0;
-
-    convert = 1;
 
     /*---------------------------------------------------------------------*/
     /*  Now read the pixels from the FITS column. If the column does not   */

--- a/group.c
+++ b/group.c
@@ -1307,7 +1307,6 @@ int ffgtam(fitsfile *gfptr,   /* FITS file pointer to grouping table HDU     */
   int memberPosition = 0;
   int grptype        = 0;
   int hdutype        = 0;
-  int useLocation    = 0;
   int nkeys          = 6;
   int found;
   int i;
@@ -1457,9 +1456,6 @@ int ffgtam(fitsfile *gfptr,   /* FITS file pointer to grouping table HDU     */
 
 	  */
 
-	  /* set the USELOCATION flag to true */
-
-	  useLocation = 1;
 
 	  /* 
 	     get the location, access type and iostate (RO, RW) of the
@@ -5394,7 +5390,9 @@ int fits_url2path(char *inpath,  /* input file path string  */
    */
 {
   char buff[FLEN_FILENAME];
+#if defined(WINNT) || defined(__WINNT__) || defined(MSDOS) || defined(__WIN32__) || defined(WIN32) || defined(VMS) || defined(vms) || defined(__vms) || defined(macintosh)
   int absolute;
+#endif
 
 #if defined(MSDOS) || defined(__WIN32__) || defined(WIN32)
   char *tmpStr;
@@ -5432,10 +5430,12 @@ int fits_url2path(char *inpath,  /* input file path string  */
     see if the URL is given as absolute w.r.t. the "local" file system
   */
 
-  if(buff[0] == '/') 
+#if defined(WINNT) || defined(__WINNT__) || defined(MSDOS) || defined(__WIN32__) || defined(WIN32) || defined(VMS) || defined(vms) || defined(__vms) || defined(macintosh)
+  if(buff[0] == '/')
     absolute = 1;
   else
     absolute = 0;
+#endif
 
 #if defined(WINNT) || defined(__WINNT__)
 

--- a/histo.c
+++ b/histo.c
@@ -1802,7 +1802,6 @@ int fits_calc_binningde(
     int datatype, imin, imax, ibin,  use_datamax = 0;
     long repeat1;
     double datamin, datamax;
-    int ncols;
 
     /* check inputs */
     
@@ -1934,7 +1933,6 @@ int fits_calc_binningde(
 	fits_get_eqcoltype(fptr, colnum[ii], &datatype,
 			   &repeat1, NULL, status);
 	
-	ncols = 1; /* Require only one iterator column, the actual column */
 
       } else { /* column expression: use parse to determine datatype and dimensions */
 
@@ -1959,7 +1957,6 @@ int fits_calc_binningde(
 
 	/* We require lParse.nCols columns to be read from input,
 	   plus one for the Temporary calculator result */
-	ncols = lParse.nCols + 1;
 	ffcprs( &lParse );
       }
 
@@ -2503,7 +2500,7 @@ int fits_make_hist(fitsfile *fptr, /* IO - pointer to table with X and Y cols; *
                              /* is equal to NULL.                           */
     int *status)
 {		  
-  double amind[4], amaxd[4], binsized[4], weightd;
+  double amind[4], amaxd[4], binsized[4];
 
   /* Copy single precision values into double precision */
   if (*status == 0) {
@@ -2515,7 +2512,6 @@ int fits_make_hist(fitsfile *fptr, /* IO - pointer to table with X and Y cols; *
       binsized[i] = (double) binsize[i];
     }
 
-    weightd = (double) weight;
 
     fits_make_histd(fptr, histptr, bitpix, naxis, naxes, colnum,
 		    amind, amaxd, binsized, weight, wtcolnum, recip,

--- a/imcompress.c
+++ b/imcompress.c
@@ -4711,7 +4711,6 @@ int fits_read_write_compressed_img(fitsfile *fptr,   /* I - FITS file pointer   
     long tfpixel[MAX_COMPRESS_DIM], tlpixel[MAX_COMPRESS_DIM];
     long rowdim[MAX_COMPRESS_DIM], offset[MAX_COMPRESS_DIM],ntemp;
     long fpixel[MAX_COMPRESS_DIM], lpixel[MAX_COMPRESS_DIM];
-    long inc[MAX_COMPRESS_DIM];
     long i5, i4, i3, i2, i1, i0, irow;
     int ii, ndim, tilenul;
     void *buffer;
@@ -4846,13 +4845,11 @@ int fits_read_write_compressed_img(fitsfile *fptr,   /* I - FITS file pointer   
         {
            fpixel[ii] = (long) infpixel[ii];
            lpixel[ii] = (long) inlpixel[ii];
-           inc[ii]    = ininc[ii];
         }
         else
         {
            fpixel[ii] = (long) inlpixel[ii];
            lpixel[ii] = (long) infpixel[ii];
-           inc[ii]    = -ininc[ii];
         }
 
         /* calc number of tiles in each dimension, and tile containing */
@@ -6921,10 +6918,6 @@ int imcomp_test_overlap (
                                    /* output image, allowing for inc factor */
     long tiledim[MAX_COMPRESS_DIM]; /* product of preceding dimensions in the */
                                  /* tile, array;  inc factor is not relevant */
-    long imgfpix[MAX_COMPRESS_DIM]; /* 1st img pix overlapping tile: 0 base, */
-                                    /*  allowing for inc factor */
-    long imglpix[MAX_COMPRESS_DIM]; /* last img pix overlapping tile 0 base, */
-                                    /*  allowing for inc factor */
     long tilefpix[MAX_COMPRESS_DIM]; /* 1st tile pix overlapping img 0 base, */
                                     /*  allowing for inc factor */
     long inc[MAX_COMPRESS_DIM]; /* local copy of input ininc */
@@ -6982,9 +6975,6 @@ int imcomp_test_overlap (
            if (tf > tl)
              return(0);  /* no overlapping pixels */
         }
-        imgfpix[ii] = maxvalue((tf - fpixel[ii] +1) / labs(inc[ii]) , 0);
-        imglpix[ii] = minvalue((tl - fpixel[ii] +1) / labs(inc[ii]) ,
-                               imgdim[ii] - 1);
 
         /* first pixel in the tile that overlaps with the image (0 base) */
         tilefpix[ii] = maxvalue(fpixel[ii] - tfpixel[ii], 0);
@@ -8703,7 +8693,7 @@ int fits_uncompress_table(fitsfile *infptr, fitsfile *outfptr, int *status)
     char *cm_buffer;   /* memory buffer for the transposed, Column-Major, chunk of the table */ 
     char *rm_buffer;   /* memory buffer for the original, Row-Major, chunk of the table */ 
     LONGLONG nrows, rmajor_colwidth[999], rmajor_colstart[1000], cmajor_colstart[1000];
-    LONGLONG cmajor_repeat[999], rmajor_repeat[999], cmajor_bytespan[999], kk;
+    LONGLONG rmajor_repeat[999], kk;
     LONGLONG headstart, datastart = 0, dataend, rowsremain, *descript, *qdescript = 0;
     LONGLONG rowstart, cvlalen, cvlastart, vlalen, vlastart;
     long repeat, width, vla_repeat, vla_address, rowspertile, ntile;
@@ -8930,16 +8920,12 @@ int fits_uncompress_table(fitsfile *infptr, fitsfile *outfptr, int *status)
         cmajor_colstart[0] = 0;
         for (ii = 0; ii < ncols; ii++) {
 
-	    cmajor_repeat[ii] = rmajor_repeat[ii] * rowspertile;
-
 	    /* starting offset of each field in the column-major table */
             if (coltype[ii] > 0) {  /* normal fixed length column */
 	          cmajor_colstart[ii + 1] = cmajor_colstart[ii] + rmajor_colwidth[ii] * rowspertile;
 	    } else { /* VLA column: reserve space for the 2nd set of Q pointers */
 	          cmajor_colstart[ii + 1] = cmajor_colstart[ii] + (rmajor_colwidth[ii] + 16) * rowspertile;
 	    }
-	    /* length of each sequence of bytes, after sorting them in signicant order */
-	    cmajor_bytespan[ii] = (rmajor_repeat[ii] * rowspertile);
 
 	    /* starting offset of each field in the  row-major table */
 	    rmajor_colstart[ii + 1] = rmajor_colstart[ii] + rmajor_colwidth[ii];

--- a/iraffits.c
+++ b/iraffits.c
@@ -1898,12 +1898,8 @@ hputc (
     char squot = 39;
     char line[100];
     char newcom[50];
-    char blank[80];
     char *v, *vp, *v1, *v2, *q1, *q2, *c1, *ve;
-    int lkeyword, lcom, lval, lc, i;
-
-    for (i = 0; i < 80; i++)
-	blank[i] = ' ';
+    int lkeyword, lcom, lval, lc;
 
     /*  find length of keyword and value */
     lkeyword = strlen (keyword);

--- a/putcoll.c
+++ b/putcoll.c
@@ -216,7 +216,7 @@ int ffpclx( fitsfile *fptr,  /* I - FITS file pointer                       */
   The binary table column being written to must have datatype 'B' or 'X'. 
 */
 {
-    LONGLONG offset, bstart, repeat, rowlen, elemnum, rstart, estart, tnull;
+    LONGLONG bstart, repeat, rowlen, elemnum, rstart, estart, tnull;
     long fbyte, lbyte, nbyte, bitloc, ndone;
     long ii, twidth, incre;
     int tcode, descrp, maxelem, hdutype;
@@ -252,9 +252,6 @@ int ffpclx( fitsfile *fptr,  /* I - FITS file pointer                       */
     lbyte = (fbit + nbit + 6) / 8;
     nbyte = lbyte - fbyte +1;
 
-    /* Save the current heapsize; ffgcprll will increment the value if */
-    /* we are writing to a variable length column. */
-    offset = (fptr->Fptr)->heapsize;
 
     /* call ffgcprll in case we are writing beyond the current end of   */
     /* the table; it will allocate more space and shift any following */

--- a/utilities/funpack.c
+++ b/utilities/funpack.c
@@ -29,13 +29,10 @@ int main (int argc, char *argv[])
 int fu_get_param (int argc, char *argv[], fpstate *fpptr)
 {
 	int	iarg;
-	char	tile[SZ_STR];
 
         if (fpptr->initialized != FP_INIT_MAGIC) {
             fp_msg ("Error: internal initialization error\n"); exit (-1);
         }
-
-	tile[0] = 0;
 
         /* by default, .fz suffix characters to be deleted from compressed file */
 	fpptr->delete_suffix = 1;

--- a/utilities/speed.c
+++ b/utilities/speed.c
@@ -526,18 +526,12 @@ void printerror( int status)
 int marktime(int *status)
 {
 #ifndef _MSC_VER
-    double telapse;
-    time_t temp;
     struct timeval tv;
-
-    temp = time(0);
 
     /* Since elapsed time is only measured to the nearest second */
     /* keep getting the time until the seconds tick just changes. */
     /* This provides more consistent timing measurements since the */
     /* intervals all start on an integer seconds. */
-
-    telapse = 0.;
 
     scpu = clock();
     start = time(0);


### PR DESCRIPTION
Remove local variables that are assigned but never read (dropping the assignment while preserving any side-effecting call on the right-hand side, e.g. the NET_SendRaw/loadData calls whose return status was ignored). In group.c fits_url2path, the 'absolute' flag is only read in the non-Unix platform branches, so its declaration and assignment are guarded by the same preprocessor condition. eval_y.c is regenerated from eval.y.