### PR TITLE
Add CI support for arm64 on Windows and run unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,21 @@ env:
 
 jobs:
   build-windows:
-    runs-on: windows-latest
+    name: build-windows (${{ matrix.arch }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            arch: x64
+            platform: x64
+            triplet: x64-windows
+          # windows-11-arm is only available to public repositories.
+          - os: windows-11-arm
+            arch: arm64
+            platform: ARM64
+            triplet: arm64-windows
     env:
       VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/vcpkg-cache
       VCPKG_BINARY_SOURCES: 'clear;files,${{ github.workspace }}/vcpkg-cache,readwrite'
@@ -28,23 +42,28 @@ jobs:
       uses: actions/cache@v6
       with:
         path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
-        key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json') }}
+        # runner.arch is what separates the two caches: runner.os is "Windows"
+        # for both, so without it x64 and arm64 would share a single key.
+        key: ${{ runner.os }}-${{ runner.arch }}-vcpkg-${{ hashFiles('vcpkg.json') }}
         restore-keys: |
-          ${{ runner.os }}-vcpkg-
+          ${{ runner.os }}-${{ runner.arch }}-vcpkg-
 
     # 1. Manually install zlib using the built-in vcpkg executable
     - name: Install zlib via vcpkg
       run: |
-        vcpkg install zlib:x64-windows
+        vcpkg install zlib:${{ matrix.triplet }}
 
-    # 2. Configure CMake by passing the toolchain file
+    # 2. Configure CMake by passing the toolchain file.
+    # -A is passed explicitly so the target architecture never depends on the
+    # generator's default for the host.
     - name: Configure CMake
       shell: powershell
       run: >
-        cmake -B ${{github.workspace}}/build 
+        cmake -B ${{github.workspace}}/build
+        -A ${{ matrix.platform }}
         -DUSE_CURL=OFF
         -DCMAKE_BUILD_TYPE=Release
-        -DVCPKG_TARGET_TRIPLET=x64-windows
+        -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }}
         -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
 
     - name: Build Project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,23 @@ IF (TESTS)
 
     install(TARGETS cookbook RUNTIME DESTINATION bin)
 
+    # Unit tests in the tests/ directory (mirrors the autotools tests.am list).
+    # Each tests/test_*.c is a standalone program linked against the library;
+    # registering them here lets `ctest` (e.g. the Windows CI) run them too.
+    FILE(GLOB UNIT_TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_*.c)
+    FOREACH(test_src ${UNIT_TEST_SOURCES})
+        GET_FILENAME_COMPONENT(test_name ${test_src} NAME_WE)
+        ADD_EXECUTABLE(${test_name} ${test_src})
+        TARGET_LINK_LIBRARIES(${test_name} ${LIB_NAME})
+        # test_macros.h and other test headers live in tests/
+        TARGET_INCLUDE_DIRECTORIES(${test_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+        ADD_TEST(NAME ${test_name} COMMAND ${test_name})
+        # A test may report itself as skipped with exit code 77 (e.g.
+        # test_drvrsmem when shared-memory services are unavailable), matching
+        # the automake convention; treat that as SKIP rather than failure.
+        SET_TESTS_PROPERTIES(${test_name} PROPERTIES SKIP_RETURN_CODE 77)
+    ENDFOREACH()
+
 ENDIF(TESTS)
 
 IF (ITERPROGS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,7 +213,14 @@ IF(HAVE_SHMEM_SERVICES)
 ENDIF()
 
 IF(WIN32 AND BUILD_SHARED_LIBS)
-    ADD_DEFINITIONS(-Dcfitsio_EXPORTS)
+    IF(TESTS)
+        # The tests/ unit tests call internal helper functions (fits_rcomp,
+        # pl_p2li, simplerng_*, ...) that are not part of the public API.  When
+        # tests are built we export the whole library via WINDOWS_EXPORT_ALL_SYMBOLS
+    ELSE()
+        # Normal build: export only the public API marked with CFITS_API.
+        ADD_DEFINITIONS(-Dcfitsio_EXPORTS)
+    ENDIF()
 ENDIF()
 
 #==============================================================================
@@ -255,6 +262,14 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}")
 #==============================================================================
 
 ADD_LIBRARY(${LIB_NAME} ${LIB_TYPE} ${H_FILES} ${SRC_FILES})
+
+# When building the unit tests, export every symbol from the Windows DLL so the
+# tests (which call internal helper functions) resolve against it, just as they
+# do with the Unix shared library.  Regular builds keep the minimal public
+# export surface (see the cfitsio_EXPORTS handling above).
+IF(WIN32 AND BUILD_SHARED_LIBS AND TESTS)
+    SET_TARGET_PROPERTIES(${LIB_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+ENDIF()
 
 # Math:
 TARGET_LINK_LIBRARIES(${LIB_NAME} ${M_LIB})


### PR DESCRIPTION
- Added a job to run the build on arm64 for windows
- Updated cmakelists.txt to also run the unit tests, this was missing on the windows CI.