### PR TITLE
Fix hex literal case handling and bare '.' in expression lexer

### DIFF
--- a/eval.l
+++ b/eval.l
@@ -135,7 +135,7 @@ hexconst        (0x[0123456789aAbBcCdDeEfF]+)
 octconst        (0o[01234567]+)
 integer		[0-9]+
 boolean         (t|f|T|F)
-real		([0-9]*"."[0-9]+)|([0-9]*"."*[0-9]+[eEdD][+-]?[0-9]+)|([0-9]*".")
+real		([0-9]*"."[0-9]+)|([0-9]*"."*[0-9]+[eEdD][+-]?[0-9]+)|([0-9]+".")
 constant        ("#"[a-zA-Z0-9_]+)|("#""$"[^\n]*"$")
 string		([\"][^\"\n]*[\"])|([\'][^\'\n]*[\'])
 variable	([a-zA-Z_][a-zA-Z0-9_]*)|("$"[^$\n]*"$")
@@ -419,7 +419,8 @@ nl		\n
 		  long int constval = 0;
 		  char *p;
 		  for (p = &(yytext[2]); *p; p++) {
-                    int v = (isdigit(*p) ? (*p - '0') : (*p - 'a' + 10));
+                    int c = (unsigned char)*p;
+                    int v = (isdigit(c) ? (c - '0') : (tolower(c) - 'a' + 10));
                     constval = (constval << 4) | v;
 		  }
 		  yylval->lng = constval;

--- a/eval_l.c
+++ b/eval_l.c
@@ -570,7 +570,7 @@ struct yy_trans_info
 static const flex_int16_t yy_accept[174] =
     {   0,
         0,    0,   31,   29,    1,   28,   18,   29,   29,   29,
-       29,   29,   29,   29,   10,    8,    8,   24,   29,   23,
+       29,   29,   29,   29,   29,    8,    8,   24,   29,   23,
        13,   13,   13,   13,    9,   13,   13,   13,   13,   13,
        17,   13,   13,   13,   13,   13,   13,   13,   29,    1,
        22,    0,   12,    0,   11,    0,   13,   20,    0,    0,
@@ -1546,7 +1546,8 @@ YY_RULE_SETUP
 		  long int constval = 0;
 		  char *p;
 		  for (p = &(yytext[2]); *p; p++) {
-                    int v = (isdigit(*p) ? (*p - '0') : (*p - 'a' + 10));
+                    int c = (unsigned char)*p;
+                    int v = (isdigit(c) ? (c - '0') : (tolower(c) - 'a' + 10));
                     constval = (constval << 4) | v;
 		  }
 		  yylval->lng = constval;
@@ -1555,7 +1556,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 430 "eval.l"
+#line 431 "eval.l"
 {
                   yylval->lng = atol(yytext);
 		  return( LONG );
@@ -1563,7 +1564,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 434 "eval.l"
+#line 435 "eval.l"
 {
                   if ((yytext[0] == 't') || (yytext[0] == 'T'))
 		    yylval->log = 1;
@@ -1574,7 +1575,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 441 "eval.l"
+#line 442 "eval.l"
 {
                   yylval->dbl = atof(yytext);
 		  return( DOUBLE );
@@ -1582,7 +1583,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 445 "eval.l"
+#line 446 "eval.l"
 {
                   if(        !fits_strcasecmp(yytext,"#PI") ) {
 		     yylval->dbl = (double)(4) * atan((double)(1));
@@ -1627,7 +1628,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 486 "eval.l"
+#line 487 "eval.l"
 {
                   int len;
                   len = strlen(yytext) - 2;
@@ -1648,7 +1649,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 503 "eval.l"
+#line 504 "eval.l"
 {
 		 int    len,type;
 		 
@@ -1674,7 +1675,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 525 "eval.l"
+#line 526 "eval.l"
 {
                   char *fname;
 		  int len=strlen(yytext);
@@ -1723,86 +1724,86 @@ YY_RULE_SETUP
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 570 "eval.l"
+#line 571 "eval.l"
 { return( INTCAST ); }
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 571 "eval.l"
+#line 572 "eval.l"
 { return( FLTCAST ); }
 	YY_BREAK
 case 17:
 YY_RULE_SETUP
-#line 572 "eval.l"
+#line 573 "eval.l"
 { return( POWER   ); }
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 573 "eval.l"
+#line 574 "eval.l"
 { return( NOT     ); }
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 574 "eval.l"
+#line 575 "eval.l"
 { return( OR      ); }
 	YY_BREAK
 case 20:
 YY_RULE_SETUP
-#line 575 "eval.l"
+#line 576 "eval.l"
 { return( AND     ); }
 	YY_BREAK
 case 21:
 YY_RULE_SETUP
-#line 576 "eval.l"
+#line 577 "eval.l"
 { return( EQ      ); }
 	YY_BREAK
 case 22:
 YY_RULE_SETUP
-#line 577 "eval.l"
+#line 578 "eval.l"
 { return( NE      ); }
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 578 "eval.l"
+#line 579 "eval.l"
 { return( GT      ); }
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-#line 579 "eval.l"
+#line 580 "eval.l"
 { return( LT      ); }
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 580 "eval.l"
+#line 581 "eval.l"
 { return( GTE     ); }
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 581 "eval.l"
+#line 582 "eval.l"
 { return( LTE     ); }
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 582 "eval.l"
+#line 583 "eval.l"
 { return( XOR     ); }
 	YY_BREAK
 case 28:
 /* rule 28 can match eol */
 YY_RULE_SETUP
-#line 583 "eval.l"
+#line 584 "eval.l"
 { return( '\n'    ); }
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-#line 584 "eval.l"
+#line 585 "eval.l"
 { return( yytext[0] ); }
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 585 "eval.l"
+#line 586 "eval.l"
 ECHO;
 	YY_BREAK
-#line 1806 "eval_l.c"
+#line 1807 "eval_l.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -2983,7 +2984,7 @@ void yyfree (void * ptr , yyscan_t yyscanner)
 
 #define YYTABLES_NAME "yytables"
 
-#line 585 "eval.l"
+#line 586 "eval.l"
 
 
 int yywrap(yyscan_t scanner)

--- a/tests/test_eval.c
+++ b/tests/test_eval.c
@@ -2396,6 +2396,95 @@ test_ffcrow_double_column_arithmetic(void)
 	call_01(ffclos, f);
 }
 
+/*
+ * Test that 0x hexadecimal literals are parsed case-insensitively.
+ * The lexer used to convert non-digits with (*p - 'a' + 10), which
+ * produced negative digit values for the uppercase forms A-F.
+ */
+static void
+test_ffcrow_hex_constant_case(void)
+{
+	fitsfile *f;
+	int status = 0;
+	double result[1];
+	int anynul;
+	int i;
+	struct { const char *expr; double value; } cases[] = {
+		{ "0x1f",       31.0 },
+		{ "0x1F",       31.0 },
+		{ "0xff",      255.0 },
+		{ "0xFF",      255.0 },
+		{ "0xFf",      255.0 },
+		{ "0xa",        10.0 },
+		{ "0xA",        10.0 },
+		{ "0xabcdef", 11259375.0 },
+		{ "0xABCDEF", 11259375.0 },
+		{ "0x10",       16.0 },
+		{ "0x0",         0.0 }
+	};
+
+	create_test_table(&f);
+
+	for (i = 0; i < (int)(sizeof(cases) / sizeof(cases[0])); i += 1) {
+		call_08(ffcrow, f, TDOUBLE, (char *)cases[i].expr,
+			1, 1, NULL, result, &anynul);
+		fail_if(result[0] != cases[i].value);
+	}
+
+	/* The other radix prefixes must keep working */
+	call_08(ffcrow, f, TDOUBLE, "0b1011", 1, 1, NULL, result, &anynul);
+	fail_if(result[0] != 11.0);
+	call_08(ffcrow, f, TDOUBLE, "0o17", 1, 1, NULL, result, &anynul);
+	fail_if(result[0] != 15.0);
+
+	call_01(ffclos, f);
+}
+
+/*
+ * Test that a lone '.' is not accepted as a floating point constant.
+ * The {real} pattern's third alternative used to allow zero digits
+ * before the decimal point, so "." lexed as the double 0.0.
+ */
+static void
+test_fftexp_bare_dot_rejected(void)
+{
+	fitsfile *f;
+	int status = 0;
+	int datatype, naxis, i;
+	long nelem, naxes[5];
+	double result[1];
+	int anynul;
+	const char *bad[] = { ".", "..", "INTCOL + .", ". + 1", ".e5" };
+	struct { const char *expr; double value; } good[] = {
+		{ "1.",     1.0 },
+		{ "12.",   12.0 },
+		{ ".5",     0.5 },
+		{ "1.5",    1.5 },
+		{ "1.5e3", 1500.0 },
+		{ "1.5E3", 1500.0 },
+		{ "0.",     0.0 }
+	};
+
+	create_test_table(&f);
+
+	for (i = 0; i < (int)(sizeof(bad) / sizeof(bad[0])); i += 1) {
+		status = 0;
+		fits_test_expr(f, (char *)bad[i], 5, &datatype, &nelem,
+			&naxis, naxes, &status);
+		fail_if(status != PARSE_SYNTAX_ERR);
+		ffcmsg();
+	}
+
+	status = 0;
+	for (i = 0; i < (int)(sizeof(good) / sizeof(good[0])); i += 1) {
+		call_08(ffcrow, f, TDOUBLE, (char *)good[i].expr,
+			1, 1, NULL, result, &anynul);
+		fail_if(result[0] != good[i].value);
+	}
+
+	call_01(ffclos, f);
+}
+
 int
 main(void)
 {
@@ -2549,6 +2638,10 @@ main(void)
 
 	/* Double-precision column arithmetic */
 	test_ffcrow_double_column_arithmetic();
+
+	/* Numeric literal lexing */
+	test_ffcrow_hex_constant_case();
+	test_fftexp_bare_dot_rejected();
 
 	remove(test_path);
 


### PR DESCRIPTION
Note: This was randomly detected using Claude when asked to write some documentation. 
Two defects in the eval.l scanner:

- `hexconst` converted non-digit characters with (*p - 'a' + 10) without folding case, so uppercase A-F yielded negative digit values. 0x1F evaluated to -1 and 0xA to -22, while 0x1f and 0xa were correct.

- The `real` pattern's third alternative was ([0-9]*"."), making the digit part optional, so a lone '.' lexed as the double 0.0 and ".." as two doubles. Requiring at least one digit rejects these as syntax errors while leaving "1.", ".5" and the exponent forms unchanged.

Regenerated eval_l.c with flex 2.6.4 and add test_ffcrow_hex_constant_case and test_fftexp_bare_dot_rejected to tests/test_eval.c.