### PR TITLE
Update Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
     open-pull-requests-limit: 10    # Prevent too many open PRs
     labels:
         - "dependabot"
+    # Only open PRs for major version bumps of Actions.
+    # Minor/patch updates are unnecessary when using floating major tags (e.g. @v4).
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     # Group updates together (newer Dependabot feature)
     groups:
       actions:


### PR DESCRIPTION
As per PR #158 and https://github.com/heasarc/cfitsio/pull/158#pullrequestreview-4880245833, this PR updates the Dependabot configuration to ignore minor and patch version number bumps in GitHub Actions workflows as they are unnecessary.