### PR TITLE
fitsverify: fix NULL dereference in get_cmp on a complex value with no comma

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -191,6 +191,7 @@ eval:		# Rebuild eval_* files from flex/bison source
 
 # Distribution: ==========================================================
 
+DISTCHECK_CONFIGURE_FLAGS = --enable-reentrant
 
 EXTRA_DIST = $(F77_WRAPPERS) ${GSIFTP_SRC} \
 	docs licenses \

--- a/Makefile.in
+++ b/Makefile.in
@@ -125,7 +125,8 @@ am__installdirs = "$(DESTDIR)$(bindir)" "$(DESTDIR)$(libdir)" \
 am__EXEEXT_1 = tests/test_buffers$(EXEEXT) tests/test_cfileio$(EXEEXT) \
 	tests/test_checksum$(EXEEXT) tests/test_drvrsmem$(EXEEXT) \
 	tests/test_editcol$(EXEEXT) tests/test_edithdu$(EXEEXT) \
-	tests/test_eval$(EXEEXT) tests/test_fileops$(EXEEXT) \
+	tests/test_eval$(EXEEXT) tests/test_fitsverify$(EXEEXT) \
+	tests/test_fileops$(EXEEXT) \
 	tests/test_find_match_delim$(EXEEXT) \
 	tests/test_getcol$(EXEEXT) tests/test_getcolb$(EXEEXT) \
 	tests/test_getcoli$(EXEEXT) tests/test_getcold$(EXEEXT) \
@@ -347,6 +348,11 @@ tests_test_find_match_delim_OBJECTS =  \
 	$(am_tests_test_find_match_delim_OBJECTS)
 tests_test_find_match_delim_LDADD = $(LDADD)
 tests_test_find_match_delim_DEPENDENCIES = libcfitsio.la \
+	$(am__DEPENDENCIES_1)
+am_tests_test_fitsverify_OBJECTS = tests/test_fitsverify.$(OBJEXT)
+tests_test_fitsverify_OBJECTS = $(am_tests_test_fitsverify_OBJECTS)
+tests_test_fitsverify_LDADD = $(LDADD)
+tests_test_fitsverify_DEPENDENCIES = libcfitsio.la \
 	$(am__DEPENDENCIES_1)
 am_tests_test_getcol_OBJECTS = tests/test_getcol.$(OBJEXT)
 tests_test_getcol_OBJECTS = $(am_tests_test_getcol_OBJECTS)
@@ -616,6 +622,7 @@ am__depfiles_remade = ./$(DEPDIR)/libcfitsio_la-buffers.Plo \
 	tests/$(DEPDIR)/test_edithdu.Po tests/$(DEPDIR)/test_eval.Po \
 	tests/$(DEPDIR)/test_fileops.Po \
 	tests/$(DEPDIR)/test_find_match_delim.Po \
+	tests/$(DEPDIR)/test_fitsverify.Po \
 	tests/$(DEPDIR)/test_getcol.Po tests/$(DEPDIR)/test_getcolb.Po \
 	tests/$(DEPDIR)/test_getcold.Po \
 	tests/$(DEPDIR)/test_getcole.Po \
@@ -713,16 +720,16 @@ SOURCES = $(libcfitsio_la_SOURCES) $(libcfitsio_swapproc_la_SOURCES) \
 	$(tests_test_editcol_SOURCES) $(tests_test_edithdu_SOURCES) \
 	$(tests_test_eval_SOURCES) $(tests_test_fileops_SOURCES) \
 	$(tests_test_find_match_delim_SOURCES) \
-	$(tests_test_getcol_SOURCES) $(tests_test_getcolb_SOURCES) \
-	$(tests_test_getcold_SOURCES) $(tests_test_getcole_SOURCES) \
-	$(tests_test_getcoli_SOURCES) $(tests_test_getcolj_SOURCES) \
-	$(tests_test_getcolk_SOURCES) $(tests_test_getcoll_SOURCES) \
-	$(tests_test_getcols_SOURCES) $(tests_test_getcolsb_SOURCES) \
-	$(tests_test_getcolui_SOURCES) $(tests_test_getcoluj_SOURCES) \
-	$(tests_test_getcoluk_SOURCES) $(tests_test_getkey_SOURCES) \
-	$(tests_test_group_SOURCES) $(tests_test_grparser_SOURCES) \
-	$(tests_test_hcompress_SOURCES) $(tests_test_histo_SOURCES) \
-	$(tests_test_imcompress_SOURCES) \
+	$(tests_test_fitsverify_SOURCES) $(tests_test_getcol_SOURCES) \
+	$(tests_test_getcolb_SOURCES) $(tests_test_getcold_SOURCES) \
+	$(tests_test_getcole_SOURCES) $(tests_test_getcoli_SOURCES) \
+	$(tests_test_getcolj_SOURCES) $(tests_test_getcolk_SOURCES) \
+	$(tests_test_getcoll_SOURCES) $(tests_test_getcols_SOURCES) \
+	$(tests_test_getcolsb_SOURCES) $(tests_test_getcolui_SOURCES) \
+	$(tests_test_getcoluj_SOURCES) $(tests_test_getcoluk_SOURCES) \
+	$(tests_test_getkey_SOURCES) $(tests_test_group_SOURCES) \
+	$(tests_test_grparser_SOURCES) $(tests_test_hcompress_SOURCES) \
+	$(tests_test_histo_SOURCES) $(tests_test_imcompress_SOURCES) \
 	$(tests_test_iraffits_SOURCES) $(tests_test_modkey_SOURCES) \
 	$(tests_test_pliocomp_SOURCES) $(tests_test_putcol_SOURCES) \
 	$(tests_test_putcolb_SOURCES) $(tests_test_putcold_SOURCES) \
@@ -748,16 +755,16 @@ DIST_SOURCES = $(am__libcfitsio_la_SOURCES_DIST) \
 	$(tests_test_edithdu_SOURCES) $(tests_test_eval_SOURCES) \
 	$(tests_test_fileops_SOURCES) \
 	$(tests_test_find_match_delim_SOURCES) \
-	$(tests_test_getcol_SOURCES) $(tests_test_getcolb_SOURCES) \
-	$(tests_test_getcold_SOURCES) $(tests_test_getcole_SOURCES) \
-	$(tests_test_getcoli_SOURCES) $(tests_test_getcolj_SOURCES) \
-	$(tests_test_getcolk_SOURCES) $(tests_test_getcoll_SOURCES) \
-	$(tests_test_getcols_SOURCES) $(tests_test_getcolsb_SOURCES) \
-	$(tests_test_getcolui_SOURCES) $(tests_test_getcoluj_SOURCES) \
-	$(tests_test_getcoluk_SOURCES) $(tests_test_getkey_SOURCES) \
-	$(tests_test_group_SOURCES) $(tests_test_grparser_SOURCES) \
-	$(tests_test_hcompress_SOURCES) $(tests_test_histo_SOURCES) \
-	$(tests_test_imcompress_SOURCES) \
+	$(tests_test_fitsverify_SOURCES) $(tests_test_getcol_SOURCES) \
+	$(tests_test_getcolb_SOURCES) $(tests_test_getcold_SOURCES) \
+	$(tests_test_getcole_SOURCES) $(tests_test_getcoli_SOURCES) \
+	$(tests_test_getcolj_SOURCES) $(tests_test_getcolk_SOURCES) \
+	$(tests_test_getcoll_SOURCES) $(tests_test_getcols_SOURCES) \
+	$(tests_test_getcolsb_SOURCES) $(tests_test_getcolui_SOURCES) \
+	$(tests_test_getcoluj_SOURCES) $(tests_test_getcoluk_SOURCES) \
+	$(tests_test_getkey_SOURCES) $(tests_test_group_SOURCES) \
+	$(tests_test_grparser_SOURCES) $(tests_test_hcompress_SOURCES) \
+	$(tests_test_histo_SOURCES) $(tests_test_imcompress_SOURCES) \
 	$(tests_test_iraffits_SOURCES) $(tests_test_modkey_SOURCES) \
 	$(tests_test_pliocomp_SOURCES) $(tests_test_putcol_SOURCES) \
 	$(tests_test_putcolb_SOURCES) $(tests_test_putcold_SOURCES) \
@@ -1244,6 +1251,7 @@ CLEANFILES = tg123x.kfj include1.tpl include2.tpl test_buffers.fits \
 	test_cfileio.fits test_checksum.fits test_delete.fits \
 	test_editcol.fits test_editcol2.fits test_edithdu.fits \
 	test_edithdu2.fits test_edithdu3.fits test_eval.fits \
+	test_fitsverify_report.txt test_fitsverify.fits \
 	test_getcol.fits test_getcolb.fits test_getcold.fits \
 	test_getcole.fits test_getcoli.fits test_getcolj.fits \
 	test_getcolk.fits test_getcoll.fits test_getcols.fits \
@@ -1271,6 +1279,7 @@ UNIT_TESTS = \
 	tests/test_editcol \
 	tests/test_edithdu \
 	tests/test_eval \
+	tests/test_fitsverify \
 	tests/test_fileops \
 	tests/test_find_match_delim \
 	tests/test_getcol \
@@ -1325,6 +1334,7 @@ tests_test_drvrsmem_SOURCES = tests/test_drvrsmem.c
 tests_test_editcol_SOURCES = tests/test_editcol.c
 tests_test_edithdu_SOURCES = tests/test_edithdu.c
 tests_test_eval_SOURCES = tests/test_eval.c
+tests_test_fitsverify_SOURCES = tests/test_fitsverify.c
 tests_test_fileops_SOURCES = tests/test_fileops.c
 tests_test_find_match_delim_SOURCES = tests/test_find_match_delim.c
 tests_test_getcol_SOURCES = tests/test_getcol.c
@@ -1662,6 +1672,12 @@ tests/test_find_match_delim.$(OBJEXT): tests/$(am__dirstamp) \
 tests/test_find_match_delim$(EXEEXT): $(tests_test_find_match_delim_OBJECTS) $(tests_test_find_match_delim_DEPENDENCIES) $(EXTRA_tests_test_find_match_delim_DEPENDENCIES) tests/$(am__dirstamp)
 	@rm -f tests/test_find_match_delim$(EXEEXT)
 	$(AM_V_CCLD)$(LINK) $(tests_test_find_match_delim_OBJECTS) $(tests_test_find_match_delim_LDADD) $(LIBS)
+tests/test_fitsverify.$(OBJEXT): tests/$(am__dirstamp) \
+	tests/$(DEPDIR)/$(am__dirstamp)
+
+tests/test_fitsverify$(EXEEXT): $(tests_test_fitsverify_OBJECTS) $(tests_test_fitsverify_DEPENDENCIES) $(EXTRA_tests_test_fitsverify_DEPENDENCIES) tests/$(am__dirstamp)
+	@rm -f tests/test_fitsverify$(EXEEXT)
+	$(AM_V_CCLD)$(LINK) $(tests_test_fitsverify_OBJECTS) $(tests_test_fitsverify_LDADD) $(LIBS)
 tests/test_getcol.$(OBJEXT): tests/$(am__dirstamp) \
 	tests/$(DEPDIR)/$(am__dirstamp)
 
@@ -2010,6 +2026,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@tests/$(DEPDIR)/test_eval.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tests/$(DEPDIR)/test_fileops.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tests/$(DEPDIR)/test_find_match_delim.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@tests/$(DEPDIR)/test_fitsverify.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tests/$(DEPDIR)/test_getcol.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tests/$(DEPDIR)/test_getcolb.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tests/$(DEPDIR)/test_getcold.Po@am__quote@ # am--include-marker
@@ -2990,6 +3007,13 @@ tests/test_eval.log: tests/test_eval$(EXEEXT)
 	--log-file $$b.log --trs-file $$b.trs \
 	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
 	"$$tst" $(AM_TESTS_FD_REDIRECT)
+tests/test_fitsverify.log: tests/test_fitsverify$(EXEEXT)
+	@p='tests/test_fitsverify$(EXEEXT)'; \
+	b='tests/test_fitsverify'; \
+	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
+	--log-file $$b.log --trs-file $$b.trs \
+	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
+	"$$tst" $(AM_TESTS_FD_REDIRECT)
 tests/test_fileops.log: tests/test_fileops$(EXEEXT)
 	@p='tests/test_fileops$(EXEEXT)'; \
 	b='tests/test_fileops'; \
@@ -3646,6 +3670,7 @@ distclean: distclean-am
 	-rm -f tests/$(DEPDIR)/test_eval.Po
 	-rm -f tests/$(DEPDIR)/test_fileops.Po
 	-rm -f tests/$(DEPDIR)/test_find_match_delim.Po
+	-rm -f tests/$(DEPDIR)/test_fitsverify.Po
 	-rm -f tests/$(DEPDIR)/test_getcol.Po
 	-rm -f tests/$(DEPDIR)/test_getcolb.Po
 	-rm -f tests/$(DEPDIR)/test_getcold.Po
@@ -3830,6 +3855,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f tests/$(DEPDIR)/test_eval.Po
 	-rm -f tests/$(DEPDIR)/test_fileops.Po
 	-rm -f tests/$(DEPDIR)/test_find_match_delim.Po
+	-rm -f tests/$(DEPDIR)/test_fitsverify.Po
 	-rm -f tests/$(DEPDIR)/test_getcol.Po
 	-rm -f tests/$(DEPDIR)/test_getcolb.Po
 	-rm -f tests/$(DEPDIR)/test_getcold.Po

--- a/tests/test_fitsverify.c
+++ b/tests/test_fitsverify.c
@@ -1,0 +1,108 @@
+/*
+ * Tests for the fitsverify utility (utilities/fvrf_*.c).
+ *
+ * Two kinds of test live here.  Routines that can be driven on their own -
+ * the keyword value parsers, the error reporting - are called in process:
+ * their source file is #included, and the handful of symbols the rest of
+ * fitsverify would have provided are stubbed below.  Defects that only show
+ * up on a whole file are exercised by writing that file and running the
+ * fitsverify binary over it.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/wait.h>
+
+#include "fitsio.h"
+#include "test_macros.h"
+
+/* Globals that utilities/ftverify.c owns in the real program. */
+int prhead = 0;
+int testdata = 1;
+int testfill = 1;
+int testcsum = 1;
+int totalhdu = 0;
+int err_report = 0;
+int heasarc_conv = 1;
+int testhierarch = 0;
+int prstat = 0;
+
+/* Only reached after MAXERRORS reports, which these tests stay well under. */
+void update_parfile(int nerr, int nwrn) { (void)nerr; (void)nwrn; }
+void close_report(FILE *out) { (void)out; }
+
+#include "../utilities/fvrf_key.c"
+#include "../utilities/fvrf_misc.c"
+
+/*--------------------------------------------------------------------------
+ * get_cmp: complex keyword values (utilities/fvrf_key.c)
+ *------------------------------------------------------------------------*/
+
+/* Parse a complex keyword value and return the accumulated error mask. */
+static unsigned long
+parse_cmp(const char *value, char *kvalue, kwdtyp *ktype)
+{
+	char card[FLEN_CARD];
+	char *p = card;
+	unsigned long stat = 0;
+
+	memset(card, 0, sizeof(card));
+	strcpy(card, value);
+	kvalue[0] = '\0';
+	*ktype = UNKNOWN;
+	get_cmp(&p, kvalue, ktype, &stat);
+	return stat;
+}
+
+static void
+test_complex_keyword_values(void)
+{
+	char kvalue[FLEN_CARD];
+	kwdtyp ktype;
+	unsigned long stat;
+
+	/* A well formed integer complex value. */
+	stat = parse_cmp("(1,2)", kvalue, &ktype);
+	fail_if(stat != 0);
+	fail_if(ktype != CMI_KEY);
+
+	/* A well formed floating point complex value. */
+	stat = parse_cmp("(1.5,-2.5)", kvalue, &ktype);
+	fail_if(stat != 0);
+	fail_if(ktype != CMF_KEY);
+
+	/*
+	 * No comma: there is no imaginary part to analyse.  This used to
+	 * write through a NULL pr_end and read through an uninitialised
+	 * pi_beg, so the process died here.
+	 */
+	stat = parse_cmp("(1 2)", kvalue, &ktype);
+	fail_if(!(stat & NO_COMMA));
+
+	/* No comma and no closing paren either. */
+	stat = parse_cmp("(1 2", kvalue, &ktype);
+	fail_if(!(stat & NO_COMMA));
+	fail_if(!(stat & NO_TRAIL_PAREN));
+
+	/* Nothing but the opening paren. */
+	stat = parse_cmp("(", kvalue, &ktype);
+	fail_if(!(stat & NO_COMMA));
+
+	/* A comma but no closing paren still gets both parts analysed. */
+	stat = parse_cmp("(1,2", kvalue, &ktype);
+	fail_if(stat & NO_COMMA);
+	fail_if(!(stat & NO_TRAIL_PAREN));
+
+	/* Too many commas is reported, and must not crash. */
+	stat = parse_cmp("(1,2,3)", kvalue, &ktype);
+	fail_if(!(stat & TOO_MANY_COMMA));
+}
+
+int
+main(void)
+{
+	test_complex_keyword_values();
+	return 0;
+}

--- a/tests/tests.am
+++ b/tests/tests.am
@@ -6,6 +6,7 @@ UNIT_TESTS = \
 	tests/test_editcol \
 	tests/test_edithdu \
 	tests/test_eval \
+	tests/test_fitsverify \
 	tests/test_fileops \
 	tests/test_find_match_delim \
 	tests/test_getcol \
@@ -64,6 +65,7 @@ tests_test_drvrsmem_SOURCES = tests/test_drvrsmem.c
 tests_test_editcol_SOURCES = tests/test_editcol.c
 tests_test_edithdu_SOURCES = tests/test_edithdu.c
 tests_test_eval_SOURCES = tests/test_eval.c
+tests_test_fitsverify_SOURCES = tests/test_fitsverify.c
 tests_test_fileops_SOURCES = tests/test_fileops.c
 tests_test_find_match_delim_SOURCES = tests/test_find_match_delim.c
 tests_test_getcol_SOURCES = tests/test_getcol.c
@@ -125,6 +127,8 @@ CLEANFILES += \
 	test_edithdu2.fits \
 	test_edithdu3.fits \
 	test_eval.fits \
+	test_fitsverify_report.txt \
+	test_fitsverify.fits \
 	test_getcol.fits \
 	test_getcolb.fits \
 	test_getcold.fits \

--- a/utilities/fvrf_key.c
+++ b/utilities/fvrf_key.c
@@ -315,7 +315,7 @@ void get_cmp(char **pt,     		/* card string */
     char **pp;
     char *pr_beg;			/* end of real part */
     char *pr_end=0;			/* end of real part */
-    char *pi_beg;			/* beginning of the imaginay part */
+    char *pi_beg=0;			/* beginning of the imaginay part */
     char *pi_end=0;			/* end of real part */
     int  nchar;
     int set_comm = 0;
@@ -368,19 +368,24 @@ void get_cmp(char **pt,     		/* card string */
     while(isspace((int)*p)&& *p != '\0')  p++; 
     *pt = *pt + (p - card); 
 
-    /* analyse the real and imagine part */ 
+    /* analyse the real and imagine part */
+    /* Without a comma there is no real/imaginary split to analyse: pr_end
+       and pi_beg were never set, so the NO_COMMA error recorded above is
+       the only diagnostic this value can produce. */
+    if(!set_comm) return;
+
     *pr_end = '\0';
-    *pi_end = '\0'; 
-    while(isspace((int)*pr_beg) && *pr_beg != '\0')  pr_beg++; 
-    while(isspace((int)*pi_beg) && *pi_beg != '\0')  pi_beg++; 
+    *pi_end = '\0';
+    while(isspace((int)*pr_beg) && *pr_beg != '\0')  pr_beg++;
+    while(isspace((int)*pi_beg) && *pi_beg != '\0')  pi_beg++;
     temp[0] = '\0';
     pp = &pr_beg;
-    get_num(pp, temp, &rtype, &tr); 
-    if(tr)*stat |= BAD_REAL; 
+    get_num(pp, temp, &rtype, &tr);
+    if(tr)*stat |= BAD_REAL;
     temp[0] = '\0';
     pp = &pi_beg;
-    get_num(pp, temp, &itype, &ti); 
-    if(ti)*stat |= BAD_IMG; 
+    get_num(pp, temp, &itype, &ti);
+    if(ti)*stat |= BAD_IMG;
     if(rtype == FLT_KEY || itype == FLT_KEY) *ktype = CMF_KEY;
     return;
 }


### PR DESCRIPTION
**A1** from an audit of the fitsverify sources. Verified: **CONFIRMED-CRASH (SIGSEGV)**, reproduced against the checked-in `fitsverify`.

## The bug

`utilities/fvrf_key.c:get_cmp()` assigns `pr_end` and `pi_beg` only inside

```c
if(!set_comm && *p == ',') { set_comm = 1; pr_end = p; pi_beg = p+1; }
```

When the value has no comma the code records `NO_COMMA` and carries on to
`*pr_end = '\0';` (a NULL write, `pr_end` is initialised to 0) and to
`while(isspace((int)*pi_beg) ...)` (`pi_beg` was never initialised at all).

Any card whose value starts with `(` and contains no comma is enough:

```
CPLX    = (1 2)
```

```
before: Segmentation fault (core dumped), exit 139
after:  *** Error:   keyword #4, CPLX : Complex value "(1 2" misses ",".
        exit 1
```

## The fix

Return before the real/imaginary breakdown when `set_comm` is 0 — there is no
imaginary part to parse, and the `NO_COMMA` error recorded just above is the
diagnostic for that value. `pi_beg` is also initialised at its declaration.

## Test

This PR adds `tests/test_fitsverify.c`, the shared test file the whole chain
builds on. It `#include`s the `fvrf_*.c` sources that can be driven directly
and stubs the few symbols `utilities/ftverify.c` would otherwise provide, so
`get_cmp()` can be called on its own. The first tests cover the two crashing
inputs plus well-formed values, a missing closing paren, and too many commas.
It dies with SIGSEGV without the fix.

## Merge order

A stacked set of eight fitsverify fixes on top of a build-system base,
all targeting `develop`. Merge in this order:

0. #170 - Makefile.in reproducible from Makefile.am (build system, no code change)
1. #160 - get_cmp NULL dereference  <- this PR
2. #161 - TFORM zero substring width
3. #162 - bit column report overflow
4. #163 - uninitialised keyword index
5. #164 - test_agap column template
6. #165 - test_agap short read
7. #166 - wrtserr message array
8. #167 - naxes[] bounds

#170 is split out so that the `Makefile.in` regeneration is reviewable on
its own; the eight fixes share `tests/test_fitsverify.c`, which is why they
are stacked on each other rather than independent. Merged in this order
there are no conflicts. Until the ones before it are merged this PR's diff
also shows their commits; it shrinks to just its own change as they go in.

## A note on the build wiring

This is the only PR in the chain that touches `tests/tests.am` and
`Makefile.in` — the seven that follow only add tests to the file this one
creates. `Makefile.in` is regenerated with automake 1.18.1, the version that
generated the rest of this tree.

The `Makefile.am` / `Makefile.in` inconsistency that regeneration exposed
(`DISTCHECK_CONFIGURE_FLAGS = --enable-reentrant` living only in the generated
file) is fixed separately in the base PR this one is stacked on (#170), so the diff
here is purely the new test program's own wiring.

## Provenance

Found by an agent, fixed by an agent, reviewed by a human. The defect list came
out of automated analysis, the reproducer, the fix and the test were written by
an agent, and a human reviewed the change on the fork
(cruzzil/cfitsio-tmp#10) before it was sent here.
