### PR TITLE
fitsverify: report the real card number in init_hdu diagnostics

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -191,6 +191,7 @@ eval:		# Rebuild eval_* files from flex/bison source
 
 # Distribution: ==========================================================
 
+DISTCHECK_CONFIGURE_FLAGS = --enable-reentrant
 
 EXTRA_DIST = $(F77_WRAPPERS) ${GSIFTP_SRC} \
 	docs licenses \

--- a/Makefile.in
+++ b/Makefile.in
@@ -125,7 +125,8 @@ am__installdirs = "$(DESTDIR)$(bindir)" "$(DESTDIR)$(libdir)" \
 am__EXEEXT_1 = tests/test_buffers$(EXEEXT) tests/test_cfileio$(EXEEXT) \
 	tests/test_checksum$(EXEEXT) tests/test_drvrsmem$(EXEEXT) \
 	tests/test_editcol$(EXEEXT) tests/test_edithdu$(EXEEXT) \
-	tests/test_eval$(EXEEXT) tests/test_fileops$(EXEEXT) \
+	tests/test_eval$(EXEEXT) tests/test_fitsverify$(EXEEXT) \
+	tests/test_fileops$(EXEEXT) \
 	tests/test_find_match_delim$(EXEEXT) \
 	tests/test_getcol$(EXEEXT) tests/test_getcolb$(EXEEXT) \
 	tests/test_getcoli$(EXEEXT) tests/test_getcold$(EXEEXT) \
@@ -347,6 +348,11 @@ tests_test_find_match_delim_OBJECTS =  \
 	$(am_tests_test_find_match_delim_OBJECTS)
 tests_test_find_match_delim_LDADD = $(LDADD)
 tests_test_find_match_delim_DEPENDENCIES = libcfitsio.la \
+	$(am__DEPENDENCIES_1)
+am_tests_test_fitsverify_OBJECTS = tests/test_fitsverify.$(OBJEXT)
+tests_test_fitsverify_OBJECTS = $(am_tests_test_fitsverify_OBJECTS)
+tests_test_fitsverify_LDADD = $(LDADD)
+tests_test_fitsverify_DEPENDENCIES = libcfitsio.la \
 	$(am__DEPENDENCIES_1)
 am_tests_test_getcol_OBJECTS = tests/test_getcol.$(OBJEXT)
 tests_test_getcol_OBJECTS = $(am_tests_test_getcol_OBJECTS)
@@ -616,6 +622,7 @@ am__depfiles_remade = ./$(DEPDIR)/libcfitsio_la-buffers.Plo \
 	tests/$(DEPDIR)/test_edithdu.Po tests/$(DEPDIR)/test_eval.Po \
 	tests/$(DEPDIR)/test_fileops.Po \
 	tests/$(DEPDIR)/test_find_match_delim.Po \
+	tests/$(DEPDIR)/test_fitsverify.Po \
 	tests/$(DEPDIR)/test_getcol.Po tests/$(DEPDIR)/test_getcolb.Po \
 	tests/$(DEPDIR)/test_getcold.Po \
 	tests/$(DEPDIR)/test_getcole.Po \
@@ -713,16 +720,16 @@ SOURCES = $(libcfitsio_la_SOURCES) $(libcfitsio_swapproc_la_SOURCES) \
 	$(tests_test_editcol_SOURCES) $(tests_test_edithdu_SOURCES) \
 	$(tests_test_eval_SOURCES) $(tests_test_fileops_SOURCES) \
 	$(tests_test_find_match_delim_SOURCES) \
-	$(tests_test_getcol_SOURCES) $(tests_test_getcolb_SOURCES) \
-	$(tests_test_getcold_SOURCES) $(tests_test_getcole_SOURCES) \
-	$(tests_test_getcoli_SOURCES) $(tests_test_getcolj_SOURCES) \
-	$(tests_test_getcolk_SOURCES) $(tests_test_getcoll_SOURCES) \
-	$(tests_test_getcols_SOURCES) $(tests_test_getcolsb_SOURCES) \
-	$(tests_test_getcolui_SOURCES) $(tests_test_getcoluj_SOURCES) \
-	$(tests_test_getcoluk_SOURCES) $(tests_test_getkey_SOURCES) \
-	$(tests_test_group_SOURCES) $(tests_test_grparser_SOURCES) \
-	$(tests_test_hcompress_SOURCES) $(tests_test_histo_SOURCES) \
-	$(tests_test_imcompress_SOURCES) \
+	$(tests_test_fitsverify_SOURCES) $(tests_test_getcol_SOURCES) \
+	$(tests_test_getcolb_SOURCES) $(tests_test_getcold_SOURCES) \
+	$(tests_test_getcole_SOURCES) $(tests_test_getcoli_SOURCES) \
+	$(tests_test_getcolj_SOURCES) $(tests_test_getcolk_SOURCES) \
+	$(tests_test_getcoll_SOURCES) $(tests_test_getcols_SOURCES) \
+	$(tests_test_getcolsb_SOURCES) $(tests_test_getcolui_SOURCES) \
+	$(tests_test_getcoluj_SOURCES) $(tests_test_getcoluk_SOURCES) \
+	$(tests_test_getkey_SOURCES) $(tests_test_group_SOURCES) \
+	$(tests_test_grparser_SOURCES) $(tests_test_hcompress_SOURCES) \
+	$(tests_test_histo_SOURCES) $(tests_test_imcompress_SOURCES) \
 	$(tests_test_iraffits_SOURCES) $(tests_test_modkey_SOURCES) \
 	$(tests_test_pliocomp_SOURCES) $(tests_test_putcol_SOURCES) \
 	$(tests_test_putcolb_SOURCES) $(tests_test_putcold_SOURCES) \
@@ -748,16 +755,16 @@ DIST_SOURCES = $(am__libcfitsio_la_SOURCES_DIST) \
 	$(tests_test_edithdu_SOURCES) $(tests_test_eval_SOURCES) \
 	$(tests_test_fileops_SOURCES) \
 	$(tests_test_find_match_delim_SOURCES) \
-	$(tests_test_getcol_SOURCES) $(tests_test_getcolb_SOURCES) \
-	$(tests_test_getcold_SOURCES) $(tests_test_getcole_SOURCES) \
-	$(tests_test_getcoli_SOURCES) $(tests_test_getcolj_SOURCES) \
-	$(tests_test_getcolk_SOURCES) $(tests_test_getcoll_SOURCES) \
-	$(tests_test_getcols_SOURCES) $(tests_test_getcolsb_SOURCES) \
-	$(tests_test_getcolui_SOURCES) $(tests_test_getcoluj_SOURCES) \
-	$(tests_test_getcoluk_SOURCES) $(tests_test_getkey_SOURCES) \
-	$(tests_test_group_SOURCES) $(tests_test_grparser_SOURCES) \
-	$(tests_test_hcompress_SOURCES) $(tests_test_histo_SOURCES) \
-	$(tests_test_imcompress_SOURCES) \
+	$(tests_test_fitsverify_SOURCES) $(tests_test_getcol_SOURCES) \
+	$(tests_test_getcolb_SOURCES) $(tests_test_getcold_SOURCES) \
+	$(tests_test_getcole_SOURCES) $(tests_test_getcoli_SOURCES) \
+	$(tests_test_getcolj_SOURCES) $(tests_test_getcolk_SOURCES) \
+	$(tests_test_getcoll_SOURCES) $(tests_test_getcols_SOURCES) \
+	$(tests_test_getcolsb_SOURCES) $(tests_test_getcolui_SOURCES) \
+	$(tests_test_getcoluj_SOURCES) $(tests_test_getcoluk_SOURCES) \
+	$(tests_test_getkey_SOURCES) $(tests_test_group_SOURCES) \
+	$(tests_test_grparser_SOURCES) $(tests_test_hcompress_SOURCES) \
+	$(tests_test_histo_SOURCES) $(tests_test_imcompress_SOURCES) \
 	$(tests_test_iraffits_SOURCES) $(tests_test_modkey_SOURCES) \
 	$(tests_test_pliocomp_SOURCES) $(tests_test_putcol_SOURCES) \
 	$(tests_test_putcolb_SOURCES) $(tests_test_putcold_SOURCES) \
@@ -1244,6 +1251,7 @@ CLEANFILES = tg123x.kfj include1.tpl include2.tpl test_buffers.fits \
 	test_cfileio.fits test_checksum.fits test_delete.fits \
 	test_editcol.fits test_editcol2.fits test_edithdu.fits \
 	test_edithdu2.fits test_edithdu3.fits test_eval.fits \
+	test_fitsverify_report.txt test_fitsverify.fits \
 	test_getcol.fits test_getcolb.fits test_getcold.fits \
 	test_getcole.fits test_getcoli.fits test_getcolj.fits \
 	test_getcolk.fits test_getcoll.fits test_getcols.fits \
@@ -1271,6 +1279,7 @@ UNIT_TESTS = \
 	tests/test_editcol \
 	tests/test_edithdu \
 	tests/test_eval \
+	tests/test_fitsverify \
 	tests/test_fileops \
 	tests/test_find_match_delim \
 	tests/test_getcol \
@@ -1325,6 +1334,7 @@ tests_test_drvrsmem_SOURCES = tests/test_drvrsmem.c
 tests_test_editcol_SOURCES = tests/test_editcol.c
 tests_test_edithdu_SOURCES = tests/test_edithdu.c
 tests_test_eval_SOURCES = tests/test_eval.c
+tests_test_fitsverify_SOURCES = tests/test_fitsverify.c
 tests_test_fileops_SOURCES = tests/test_fileops.c
 tests_test_find_match_delim_SOURCES = tests/test_find_match_delim.c
 tests_test_getcol_SOURCES = tests/test_getcol.c
@@ -1662,6 +1672,12 @@ tests/test_find_match_delim.$(OBJEXT): tests/$(am__dirstamp) \
 tests/test_find_match_delim$(EXEEXT): $(tests_test_find_match_delim_OBJECTS) $(tests_test_find_match_delim_DEPENDENCIES) $(EXTRA_tests_test_find_match_delim_DEPENDENCIES) tests/$(am__dirstamp)
 	@rm -f tests/test_find_match_delim$(EXEEXT)
 	$(AM_V_CCLD)$(LINK) $(tests_test_find_match_delim_OBJECTS) $(tests_test_find_match_delim_LDADD) $(LIBS)
+tests/test_fitsverify.$(OBJEXT): tests/$(am__dirstamp) \
+	tests/$(DEPDIR)/$(am__dirstamp)
+
+tests/test_fitsverify$(EXEEXT): $(tests_test_fitsverify_OBJECTS) $(tests_test_fitsverify_DEPENDENCIES) $(EXTRA_tests_test_fitsverify_DEPENDENCIES) tests/$(am__dirstamp)
+	@rm -f tests/test_fitsverify$(EXEEXT)
+	$(AM_V_CCLD)$(LINK) $(tests_test_fitsverify_OBJECTS) $(tests_test_fitsverify_LDADD) $(LIBS)
 tests/test_getcol.$(OBJEXT): tests/$(am__dirstamp) \
 	tests/$(DEPDIR)/$(am__dirstamp)
 
@@ -2010,6 +2026,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@tests/$(DEPDIR)/test_eval.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tests/$(DEPDIR)/test_fileops.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tests/$(DEPDIR)/test_find_match_delim.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@tests/$(DEPDIR)/test_fitsverify.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tests/$(DEPDIR)/test_getcol.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tests/$(DEPDIR)/test_getcolb.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tests/$(DEPDIR)/test_getcold.Po@am__quote@ # am--include-marker
@@ -2990,6 +3007,13 @@ tests/test_eval.log: tests/test_eval$(EXEEXT)
 	--log-file $$b.log --trs-file $$b.trs \
 	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
 	"$$tst" $(AM_TESTS_FD_REDIRECT)
+tests/test_fitsverify.log: tests/test_fitsverify$(EXEEXT)
+	@p='tests/test_fitsverify$(EXEEXT)'; \
+	b='tests/test_fitsverify'; \
+	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
+	--log-file $$b.log --trs-file $$b.trs \
+	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
+	"$$tst" $(AM_TESTS_FD_REDIRECT)
 tests/test_fileops.log: tests/test_fileops$(EXEEXT)
 	@p='tests/test_fileops$(EXEEXT)'; \
 	b='tests/test_fileops'; \
@@ -3646,6 +3670,7 @@ distclean: distclean-am
 	-rm -f tests/$(DEPDIR)/test_eval.Po
 	-rm -f tests/$(DEPDIR)/test_fileops.Po
 	-rm -f tests/$(DEPDIR)/test_find_match_delim.Po
+	-rm -f tests/$(DEPDIR)/test_fitsverify.Po
 	-rm -f tests/$(DEPDIR)/test_getcol.Po
 	-rm -f tests/$(DEPDIR)/test_getcolb.Po
 	-rm -f tests/$(DEPDIR)/test_getcold.Po
@@ -3830,6 +3855,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f tests/$(DEPDIR)/test_eval.Po
 	-rm -f tests/$(DEPDIR)/test_fileops.Po
 	-rm -f tests/$(DEPDIR)/test_find_match_delim.Po
+	-rm -f tests/$(DEPDIR)/test_fitsverify.Po
 	-rm -f tests/$(DEPDIR)/test_getcol.Po
 	-rm -f tests/$(DEPDIR)/test_getcolb.Po
 	-rm -f tests/$(DEPDIR)/test_getcold.Po

--- a/tests/test_fitsverify.c
+++ b/tests/test_fitsverify.c
@@ -1,0 +1,108 @@
+/*
+ * Tests for the fitsverify utility (utilities/fvrf_*.c).
+ *
+ * Two kinds of test live here.  Routines that can be driven on their own -
+ * the keyword value parsers, the error reporting - are called in process:
+ * their source file is #included, and the handful of symbols the rest of
+ * fitsverify would have provided are stubbed below.  Defects that only show
+ * up on a whole file are exercised by writing that file and running the
+ * fitsverify binary over it.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/wait.h>
+
+#include "fitsio.h"
+#include "test_macros.h"
+
+/* Globals that utilities/ftverify.c owns in the real program. */
+int prhead = 0;
+int testdata = 1;
+int testfill = 1;
+int testcsum = 1;
+int totalhdu = 0;
+int err_report = 0;
+int heasarc_conv = 1;
+int testhierarch = 0;
+int prstat = 0;
+
+/* Only reached after MAXERRORS reports, which these tests stay well under. */
+void update_parfile(int nerr, int nwrn) { (void)nerr; (void)nwrn; }
+void close_report(FILE *out) { (void)out; }
+
+#include "../utilities/fvrf_key.c"
+#include "../utilities/fvrf_misc.c"
+
+/*--------------------------------------------------------------------------
+ * get_cmp: complex keyword values (utilities/fvrf_key.c)
+ *------------------------------------------------------------------------*/
+
+/* Parse a complex keyword value and return the accumulated error mask. */
+static unsigned long
+parse_cmp(const char *value, char *kvalue, kwdtyp *ktype)
+{
+	char card[FLEN_CARD];
+	char *p = card;
+	unsigned long stat = 0;
+
+	memset(card, 0, sizeof(card));
+	strcpy(card, value);
+	kvalue[0] = '\0';
+	*ktype = UNKNOWN;
+	get_cmp(&p, kvalue, ktype, &stat);
+	return stat;
+}
+
+static void
+test_complex_keyword_values(void)
+{
+	char kvalue[FLEN_CARD];
+	kwdtyp ktype;
+	unsigned long stat;
+
+	/* A well formed integer complex value. */
+	stat = parse_cmp("(1,2)", kvalue, &ktype);
+	fail_if(stat != 0);
+	fail_if(ktype != CMI_KEY);
+
+	/* A well formed floating point complex value. */
+	stat = parse_cmp("(1.5,-2.5)", kvalue, &ktype);
+	fail_if(stat != 0);
+	fail_if(ktype != CMF_KEY);
+
+	/*
+	 * No comma: there is no imaginary part to analyse.  This used to
+	 * write through a NULL pr_end and read through an uninitialised
+	 * pi_beg, so the process died here.
+	 */
+	stat = parse_cmp("(1 2)", kvalue, &ktype);
+	fail_if(!(stat & NO_COMMA));
+
+	/* No comma and no closing paren either. */
+	stat = parse_cmp("(1 2", kvalue, &ktype);
+	fail_if(!(stat & NO_COMMA));
+	fail_if(!(stat & NO_TRAIL_PAREN));
+
+	/* Nothing but the opening paren. */
+	stat = parse_cmp("(", kvalue, &ktype);
+	fail_if(!(stat & NO_COMMA));
+
+	/* A comma but no closing paren still gets both parts analysed. */
+	stat = parse_cmp("(1,2", kvalue, &ktype);
+	fail_if(stat & NO_COMMA);
+	fail_if(!(stat & NO_TRAIL_PAREN));
+
+	/* Too many commas is reported, and must not crash. */
+	stat = parse_cmp("(1,2,3)", kvalue, &ktype);
+	fail_if(!(stat & TOO_MANY_COMMA));
+}
+
+int
+main(void)
+{
+	test_complex_keyword_values();
+	return 0;
+}

--- a/tests/test_fitsverify.c
+++ b/tests/test_fitsverify.c
@@ -341,6 +341,50 @@ test_bit_column_report(void)
 	check_bit_column(3996);
 }
 
+/*--------------------------------------------------------------------------
+ * init_hdu: the card number printed for the first cards of an HDU
+ * (utilities/fvrf_head.c)
+ *------------------------------------------------------------------------*/
+
+/* An extension whose XTENSION value is an integer rather than a string. */
+static void
+write_bad_xtension_table(void)
+{
+	long n;
+	FILE *fp = open_testfile(&n);
+
+	put_card(fp, &n, "XTENSION=                 1234");
+	put_card(fp, &n, "BITPIX  =                    8");
+	put_card(fp, &n, "NAXIS   =                    2");
+	put_card(fp, &n, "NAXIS1  =                   10");
+	put_card(fp, &n, "NAXIS2  =                    1");
+	put_card(fp, &n, "PCOUNT  =                    0");
+	put_card(fp, &n, "GCOUNT  =                    1");
+	put_card(fp, &n, "TFIELDS =                    1");
+	put_card(fp, &n, "TFORM1  = '10A     '");
+	put_card(fp, &n, "TTYPE1  = 'COL1    '");
+	put_card(fp, &n, "END");
+	pad_block(fp, &n);
+
+	put_bytes(fp, &n, 'x', 10);
+	close_testfile(fp, &n);
+}
+
+static void
+test_first_card_keyword_index(void)
+{
+	/*
+	 * init_hdu parses the first cards of an HDU into an automatic FitsKey
+	 * whose kindex was never assigned, so this diagnostic used to carry
+	 * whatever happened to be on the stack.  XTENSION is card 1.
+	 */
+	write_bad_xtension_table();
+	check_no_crash("an XTENSION value that is not a string");
+
+	fail_if(count_in_report(
+	    "Keyword #1, XTENSION: \"1234\" is not a string.") != 1);
+}
+
 int
 main(void)
 {
@@ -355,6 +399,7 @@ main(void)
 
 	test_tform_substring_width();
 	test_bit_column_report();
+	test_first_card_keyword_index();
 
 	remove(TESTFILE);
 	remove(REPORT);

--- a/tests/test_fitsverify.c
+++ b/tests/test_fitsverify.c
@@ -255,6 +255,92 @@ test_tform_substring_width(void)
 	}
 }
 
+/*--------------------------------------------------------------------------
+ * iterdata: the bit column justification report (utilities/fvrf_data.c)
+ *------------------------------------------------------------------------*/
+
+/* Count occurrences of a string in the report. */
+static int
+count_in_report(const char *needle)
+{
+	FILE *fp = fopen(REPORT, "r");
+	char line[4096];
+	int nfound = 0;
+
+	fail_if(fp == NULL);
+	while (fgets(line, sizeof(line), fp) != NULL) {
+		char *p = line;
+
+		while ((p = strstr(p, needle)) != NULL) {
+			nfound++;
+			p += strlen(needle);
+		}
+	}
+	fclose(fp);
+	return nfound;
+}
+
+/*
+ * A binary table holding a single X column of nbits bits.  nbits is chosen
+ * by the caller so that it is not a multiple of 8, which leaves fill bits in
+ * the last byte; the data is all ones, so those fill bits are set and the
+ * "not left justified" report is produced.
+ */
+static void
+write_bit_column_table(int nbits)
+{
+	long n;
+	FILE *fp = open_testfile(&n);
+	long nbytes = (nbits + 7) / 8;
+	char card[81];
+
+	put_card(fp, &n, "XTENSION= 'BINTABLE'");
+	put_card(fp, &n, "BITPIX  =                    8");
+	put_card(fp, &n, "NAXIS   =                    2");
+	snprintf(card, sizeof(card), "NAXIS1  = %20ld", nbytes);
+	put_card(fp, &n, card);
+	put_card(fp, &n, "NAXIS2  =                    1");
+	put_card(fp, &n, "PCOUNT  =                    0");
+	put_card(fp, &n, "GCOUNT  =                    1");
+	put_card(fp, &n, "TFIELDS =                    1");
+	snprintf(card, sizeof(card), "TFORM1  = '%dX'", nbits);
+	put_card(fp, &n, card);
+	put_card(fp, &n, "TTYPE1  = 'BITS    '");
+	put_card(fp, &n, "END");
+	pad_block(fp, &n);
+
+	put_bytes(fp, &n, 0xff, nbytes);
+	close_testfile(fp, &n);
+}
+
+static void
+check_bit_column(int nbits)
+{
+	char what[64];
+
+	snprintf(what, sizeof(what), "a %dX column", nbits);
+	write_bit_column_table(nbits);
+	check_no_crash(what);
+
+	fail_if(count_in_report("is not left justified.") != 1);
+	/*
+	 * errmes is 256 bytes and each element costs five of them, so a
+	 * bounded report can never hold much more than fifty.  An unbounded
+	 * one prints every byte of the column.
+	 */
+	fail_if(count_in_report("0x") > 64);
+}
+
+static void
+test_bit_column_report(void)
+{
+	/* 100 bits in a 13 byte row: the report fits in errmes. */
+	check_bit_column(100);
+
+	/* 3996 bits in a 500 byte row: it does not. */
+	check_bit_column(3996);
+}
+
 int
 main(void)
 {
@@ -268,6 +354,7 @@ main(void)
 	}
 
 	test_tform_substring_width();
+	test_bit_column_report();
 
 	remove(TESTFILE);
 	remove(REPORT);

--- a/tests/test_fitsverify.c
+++ b/tests/test_fitsverify.c
@@ -100,9 +100,176 @@ test_complex_keyword_values(void)
 	fail_if(!(stat & TOO_MANY_COMMA));
 }
 
+/*--------------------------------------------------------------------------
+ * Driving the fitsverify binary over a file built for the purpose
+ *------------------------------------------------------------------------*/
+
+#define FITSVERIFY	"./fitsverify"
+#define TESTFILE	"test_fitsverify.fits"
+#define REPORT		"test_fitsverify_report.txt"
+
+/* Write one 80 column card, blank padded. */
+static void
+put_card(FILE *fp, long *nbytes, const char *card)
+{
+	char buf[81];
+
+	snprintf(buf, sizeof(buf), "%-80.80s", card);
+	fwrite(buf, 1, 80, fp);
+	*nbytes += 80;
+}
+
+/* Write count copies of one byte. */
+static void
+put_bytes(FILE *fp, long *nbytes, int byte, long count)
+{
+	long i;
+
+	for (i = 0; i < count; i++) {
+		fputc(byte, fp);
+		(*nbytes)++;
+	}
+}
+
+/* Pad with blanks out to the next 2880 byte block. */
+static void
+pad_block(FILE *fp, long *nbytes)
+{
+	while (*nbytes % 2880) {
+		fputc(' ', fp);
+		(*nbytes)++;
+	}
+}
+
+/* Start TESTFILE with an empty primary array that allows extensions. */
+static FILE *
+open_testfile(long *nbytes)
+{
+	FILE *fp = fopen(TESTFILE, "wb");
+
+	fail_if(fp == NULL);
+	*nbytes = 0;
+	put_card(fp, nbytes, "SIMPLE  =                    T");
+	put_card(fp, nbytes, "BITPIX  =                    8");
+	put_card(fp, nbytes, "NAXIS   =                    0");
+	put_card(fp, nbytes, "EXTEND  =                    T");
+	put_card(fp, nbytes, "END");
+	pad_block(fp, nbytes);
+	return fp;
+}
+
+static void
+close_testfile(FILE *fp, long *nbytes)
+{
+	pad_block(fp, nbytes);
+	fail_if(fclose(fp) != 0);
+}
+
+/*
+ * Run fitsverify on TESTFILE and return the raw wait status.  fork/exec
+ * rather than system(), so that a fatal signal shows up as WIFSIGNALED
+ * instead of being flattened into the shell's 128+n exit status.
+ */
+static int
+run_fitsverify(void)
+{
+	pid_t pid;
+	int st = 0;
+
+	pid = fork();
+	fail_if(pid < 0);
+	if (pid == 0) {
+		if (freopen(REPORT, "w", stdout) == NULL)
+			_exit(126);
+		if (dup2(fileno(stdout), fileno(stderr)) < 0)
+			_exit(126);
+		execl(FITSVERIFY, FITSVERIFY, TESTFILE, (char *)NULL);
+		_exit(127);
+	}
+	fail_if(waitpid(pid, &st, 0) != pid);
+	return st;
+}
+
+/* Verify the run finished on its own terms, and return its exit status. */
+static int
+check_no_crash(const char *what)
+{
+	int st = run_fitsverify();
+
+	if (WIFSIGNALED(st))
+		fprintf(stderr, "fitsverify died on %s with signal %d\n",
+			what, WTERMSIG(st));
+	fail_if(WIFSIGNALED(st));
+	/* 126/127: the binary could not be run at all. */
+	fail_if(WEXITSTATUS(st) == 126 || WEXITSTATUS(st) == 127);
+	return WEXITSTATUS(st);
+}
+
+/*--------------------------------------------------------------------------
+ * test_bin_ext: the "rAw" TFORM check (utilities/fvrf_head.c)
+ *------------------------------------------------------------------------*/
+
+/* A one column binary table with the given TFORM. */
+static void
+write_bintable_column(const char *tform)
+{
+	long n;
+	FILE *fp = open_testfile(&n);
+	char card[81];
+
+	put_card(fp, &n, "XTENSION= 'BINTABLE'");
+	put_card(fp, &n, "BITPIX  =                    8");
+	put_card(fp, &n, "NAXIS   =                    2");
+	put_card(fp, &n, "NAXIS1  =                   10");
+	put_card(fp, &n, "NAXIS2  =                    1");
+	put_card(fp, &n, "PCOUNT  =                    0");
+	put_card(fp, &n, "GCOUNT  =                    1");
+	put_card(fp, &n, "TFIELDS =                    1");
+	snprintf(card, sizeof(card), "TFORM1  = '%-8s'", tform);
+	put_card(fp, &n, card);
+	put_card(fp, &n, "TTYPE1  = 'COL1    '");
+	put_card(fp, &n, "END");
+	pad_block(fp, &n);
+
+	put_bytes(fp, &n, 'x', 10);
+	close_testfile(fp, &n);
+}
+
+static void
+test_tform_substring_width(void)
+{
+	/*
+	 * The check divides the repeat count by the substring width taken
+	 * straight from the TFORM value, and only guards it with isdigit(),
+	 * which admits '0'.  A width of zero used to raise SIGFPE.
+	 */
+	static const char *tforms[] = { "10A0", "0A0", "3A0", "10A", "10A5" };
+	size_t i;
+
+	for (i = 0; i < sizeof(tforms) / sizeof(tforms[0]); i++) {
+		char what[64];
+
+		snprintf(what, sizeof(what), "TFORM '%s'", tforms[i]);
+		write_bintable_column(tforms[i]);
+		check_no_crash(what);
+	}
+}
+
 int
 main(void)
 {
 	test_complex_keyword_values();
+
+	if (access(FITSVERIFY, X_OK) != 0) {
+		fprintf(stderr,
+			"%s has not been built; skipping the tests "
+			"that need it\n", FITSVERIFY);
+		return 0;
+	}
+
+	test_tform_substring_width();
+
+	remove(TESTFILE);
+	remove(REPORT);
 	return 0;
 }

--- a/tests/tests.am
+++ b/tests/tests.am
@@ -6,6 +6,7 @@ UNIT_TESTS = \
 	tests/test_editcol \
 	tests/test_edithdu \
 	tests/test_eval \
+	tests/test_fitsverify \
 	tests/test_fileops \
 	tests/test_find_match_delim \
 	tests/test_getcol \
@@ -64,6 +65,7 @@ tests_test_drvrsmem_SOURCES = tests/test_drvrsmem.c
 tests_test_editcol_SOURCES = tests/test_editcol.c
 tests_test_edithdu_SOURCES = tests/test_edithdu.c
 tests_test_eval_SOURCES = tests/test_eval.c
+tests_test_fitsverify_SOURCES = tests/test_fitsverify.c
 tests_test_fileops_SOURCES = tests/test_fileops.c
 tests_test_find_match_delim_SOURCES = tests/test_find_match_delim.c
 tests_test_getcol_SOURCES = tests/test_getcol.c
@@ -125,6 +127,8 @@ CLEANFILES += \
 	test_edithdu2.fits \
 	test_edithdu3.fits \
 	test_eval.fits \
+	test_fitsverify_report.txt \
+	test_fitsverify.fits \
 	test_getcol.fits \
 	test_getcolb.fits \
 	test_getcold.fits \

--- a/utilities/fvrf_data.c
+++ b/utilities/fvrf_data.c
@@ -542,8 +542,12 @@ data_end:
 
     /* bit column working space */
     static unsigned char bdata;
+    /* trailing text of the bit justification report, appended after however
+       many column bytes fit in errmes */
+#define NOTLEFTJUST "is not left justified."
+    size_t nchar;
 
-    int i; 
+    int i;
     long j,k,l;
     long nelem;
 
@@ -589,14 +593,25 @@ data_end:
                j = (k+1)*repeat[i];
                bdata = (unsigned char)data[j]; 
                if( bdata & usrpt->mask[i] ) { 
-                  sprintf(errmes, 
-                    "Row #%ld, and Column #%d: X vector ", firstn+k, 
-                      fits_iter_get_colnum(&(iter_col[i]))); 
+                  snprintf(errmes, sizeof(errmes),
+                    "Row #%ld, and Column #%d: X vector ", firstn+k,
+                      fits_iter_get_colnum(&(iter_col[i])));
+                  nchar = strlen(errmes);
                   for (l = 1; l<= repeat[i]; l++) {
-                     sprintf(comm, "0x%02x ", (unsigned char) data[k*repeat[i]+l]);
-                     strcat(errmes,comm); 
+                     /* repeat[i] is the width of the column in bytes and can
+                        be arbitrarily large, so stop before errmes fills up,
+                        leaving room for the elision and the trailing text */
+                     if(nchar + 5 + 4 + strlen(NOTLEFTJUST) >= sizeof(errmes)) {
+                        strcpy(errmes+nchar,"... ");
+                        nchar += 4;
+                        break;
+                     }
+                     snprintf(comm, sizeof(comm), "0x%02x ",
+                        (unsigned char) data[k*repeat[i]+l]);
+                     strcpy(errmes+nchar,comm);
+                     nchar += strlen(comm);
                   }
-                  strcat(errmes,"is not left justified."); 
+                  strcpy(errmes+nchar,NOTLEFTJUST);
                   wrterr(usrpt->out,errmes,2);
                   strcpy(errmes,
           "             (Other rows may have errors).");

--- a/utilities/fvrf_head.c
+++ b/utilities/fvrf_head.c
@@ -2441,7 +2441,14 @@ void test_bin_ext(fitsfile *infits, 	/* input fits file   */
         p++;
 	if(!isdigit((int)*p))continue;
 	width = (int)strtol(p,NULL,10);
-	if(repeat%width != 0)  { 
+	if(width == 0)  {
+	    sprintf(errmes,
+	 "TFORM %s of column %d: the substring width must not be zero.",
+	    tform[i], i+1);
+            wrterr(out,errmes,1);
+            continue;
+        }
+	if(repeat%width != 0)  {
 	    sprintf(errmes,
 	 "TFORM %s of column %d: repeat %d is not the multiple of the width %d",
 	    tform[i], i+1, repeat, width);

--- a/utilities/fvrf_head.c
+++ b/utilities/fvrf_head.c
@@ -195,7 +195,7 @@ void init_hdu(fitsfile *infits, 	/* input fits file   */
     LONGLONG lv,lu=0L; 
     
 
-    FitsKey tmpkey;
+    FitsKey tmpkey = {"", UNKNOWN, "", 0, 0};
 
     hduptr->hdunum = hdunum;
     hduptr->hdutype = hdutype;
@@ -251,6 +251,7 @@ void init_hdu(fitsfile *infits, 	/* input fits file   */
     }
 
     /* Parse the XTENSION/SIMPLEX  keyword */ 
+    tmpkey.kindex = 1;
     fits_parse_card(out, 1, cards[0], tmpkey.kname, 
         &(tmpkey.ktype), tmpkey.kvalue,comm); 
     if( *(tmpkey.kvalue) == ' ') {
@@ -327,6 +328,7 @@ void init_hdu(fitsfile *infits, 	/* input fits file   */
 
     /* Parse the keywords NAXISn */ 
     for (j = 3; j < 3 + hduptr->naxis; j++){  
+        tmpkey.kindex = 1+j;
         fits_parse_card(out, 1+j,cards[j], tmpkey.kname, 
 	    &(tmpkey.ktype), tmpkey.kvalue,comm); 
         p = tmpkey.kname+5; 
@@ -416,6 +418,7 @@ void init_hdu(fitsfile *infits, 	/* input fits file   */
     hduptr->tkeys = i; 
 
     /* parse the END key */ 
+    tmpkey.kindex = m+1;
     fits_parse_card(out,m+1,cards[hduptr->nkeys-1],
          tmpkey.kname,&(tmpkey.ktype),tmpkey.kvalue,comm) ; 
     

--- a/utilities/fvrf_key.c
+++ b/utilities/fvrf_key.c
@@ -315,7 +315,7 @@ void get_cmp(char **pt,     		/* card string */
     char **pp;
     char *pr_beg;			/* end of real part */
     char *pr_end=0;			/* end of real part */
-    char *pi_beg;			/* beginning of the imaginay part */
+    char *pi_beg=0;			/* beginning of the imaginay part */
     char *pi_end=0;			/* end of real part */
     int  nchar;
     int set_comm = 0;
@@ -368,19 +368,24 @@ void get_cmp(char **pt,     		/* card string */
     while(isspace((int)*p)&& *p != '\0')  p++; 
     *pt = *pt + (p - card); 
 
-    /* analyse the real and imagine part */ 
+    /* analyse the real and imagine part */
+    /* Without a comma there is no real/imaginary split to analyse: pr_end
+       and pi_beg were never set, so the NO_COMMA error recorded above is
+       the only diagnostic this value can produce. */
+    if(!set_comm) return;
+
     *pr_end = '\0';
-    *pi_end = '\0'; 
-    while(isspace((int)*pr_beg) && *pr_beg != '\0')  pr_beg++; 
-    while(isspace((int)*pi_beg) && *pi_beg != '\0')  pi_beg++; 
+    *pi_end = '\0';
+    while(isspace((int)*pr_beg) && *pr_beg != '\0')  pr_beg++;
+    while(isspace((int)*pi_beg) && *pi_beg != '\0')  pi_beg++;
     temp[0] = '\0';
     pp = &pr_beg;
-    get_num(pp, temp, &rtype, &tr); 
-    if(tr)*stat |= BAD_REAL; 
+    get_num(pp, temp, &rtype, &tr);
+    if(tr)*stat |= BAD_REAL;
     temp[0] = '\0';
     pp = &pi_beg;
-    get_num(pp, temp, &itype, &ti); 
-    if(ti)*stat |= BAD_IMG; 
+    get_num(pp, temp, &itype, &ti);
+    if(ti)*stat |= BAD_IMG;
     if(rtype == FLT_KEY || itype == FLT_KEY) *ktype = CMF_KEY;
     return;
 }


### PR DESCRIPTION
**A4** from an audit of the fitsverify sources. Verified: **CONFIRMED-DIVERGENCE**, reproduced against the checked-in `fitsverify`.

## The bug

`utilities/fvrf_head.c:init_hdu()` parses the first cards of every HDU into

```c
FitsKey tmpkey;      /* automatic, never initialised */
```

`tmpkey.kindex` is never assigned but is read and printed — directly at the
"is not allowed" / "is duplicated" messages, and indirectly via `check_log()`,
`check_str()` and `check_int()`, which all print `pkey->kindex`. It is an
uninitialised read, and the garbage lands in user-facing output:

```
before: *** Error:   Keyword #1418221847, XTENSION: "1234" is not a string.
after:  *** Error:   Keyword #1, XTENSION: "1234" is not a string.
```

## The fix

Zero the struct at its declaration and set `kindex` to the card number that is
already being passed to `fits_parse_card` at each of the three call sites: `1`
for the first card, `1+j` in the NAXISn loop, `m+1` for END. Zeroing alone
would remove the uninitialised read but still print `#0`, so both halves matter.

Healthy files are unaffected — the field is only ever printed on an error path.

## Test

`tests/test_fitsverify.c` gains an extension whose `XTENSION` value is an
integer rather than a string, and requires the exact diagnostic — index
included — in the report. Without the fix the index is a random 9-digit number
and the test fails.

## Merge order

A stacked set of eight fitsverify fixes on top of a build-system base,
all targeting `develop`. Merge in this order:

0. #170 - Makefile.in reproducible from Makefile.am (build system, no code change)
1. #160 - get_cmp NULL dereference
2. #161 - TFORM zero substring width
3. #162 - bit column report overflow
4. #163 - uninitialised keyword index  <- this PR
5. #164 - test_agap column template
6. #165 - test_agap short read
7. #166 - wrtserr message array
8. #167 - naxes[] bounds

#170 is split out so that the `Makefile.in` regeneration is reviewable on
its own; the eight fixes share `tests/test_fitsverify.c`, which is why they
are stacked on each other rather than independent. Merged in this order
there are no conflicts. Until the ones before it are merged this PR's diff
also shows their commits; it shrinks to just its own change as they go in.

## Provenance

Found by an agent, fixed by an agent, reviewed by a human. The defect list came
out of automated analysis, the reproducer, the fix and the test were written by
an agent, and a human reviewed the change on the fork
(cruzzil/cfitsio-tmp#13) before it was sent here.
