### PR TITLE
fitsverify: bound the naxes[] accesses on a binary table

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -191,6 +191,7 @@ eval:		# Rebuild eval_* files from flex/bison source
 
 # Distribution: ==========================================================
 
+DISTCHECK_CONFIGURE_FLAGS = --enable-reentrant
 
 EXTRA_DIST = $(F77_WRAPPERS) ${GSIFTP_SRC} \
 	docs licenses \

--- a/Makefile.in
+++ b/Makefile.in
@@ -125,7 +125,8 @@ am__installdirs = "$(DESTDIR)$(bindir)" "$(DESTDIR)$(libdir)" \
 am__EXEEXT_1 = tests/test_buffers$(EXEEXT) tests/test_cfileio$(EXEEXT) \
 	tests/test_checksum$(EXEEXT) tests/test_drvrsmem$(EXEEXT) \
 	tests/test_editcol$(EXEEXT) tests/test_edithdu$(EXEEXT) \
-	tests/test_eval$(EXEEXT) tests/test_fileops$(EXEEXT) \
+	tests/test_eval$(EXEEXT) tests/test_fitsverify$(EXEEXT) \
+	tests/test_fileops$(EXEEXT) \
 	tests/test_find_match_delim$(EXEEXT) \
 	tests/test_getcol$(EXEEXT) tests/test_getcolb$(EXEEXT) \
 	tests/test_getcoli$(EXEEXT) tests/test_getcold$(EXEEXT) \
@@ -347,6 +348,11 @@ tests_test_find_match_delim_OBJECTS =  \
 	$(am_tests_test_find_match_delim_OBJECTS)
 tests_test_find_match_delim_LDADD = $(LDADD)
 tests_test_find_match_delim_DEPENDENCIES = libcfitsio.la \
+	$(am__DEPENDENCIES_1)
+am_tests_test_fitsverify_OBJECTS = tests/test_fitsverify.$(OBJEXT)
+tests_test_fitsverify_OBJECTS = $(am_tests_test_fitsverify_OBJECTS)
+tests_test_fitsverify_LDADD = $(LDADD)
+tests_test_fitsverify_DEPENDENCIES = libcfitsio.la \
 	$(am__DEPENDENCIES_1)
 am_tests_test_getcol_OBJECTS = tests/test_getcol.$(OBJEXT)
 tests_test_getcol_OBJECTS = $(am_tests_test_getcol_OBJECTS)
@@ -616,6 +622,7 @@ am__depfiles_remade = ./$(DEPDIR)/libcfitsio_la-buffers.Plo \
 	tests/$(DEPDIR)/test_edithdu.Po tests/$(DEPDIR)/test_eval.Po \
 	tests/$(DEPDIR)/test_fileops.Po \
 	tests/$(DEPDIR)/test_find_match_delim.Po \
+	tests/$(DEPDIR)/test_fitsverify.Po \
 	tests/$(DEPDIR)/test_getcol.Po tests/$(DEPDIR)/test_getcolb.Po \
 	tests/$(DEPDIR)/test_getcold.Po \
 	tests/$(DEPDIR)/test_getcole.Po \
@@ -713,16 +720,16 @@ SOURCES = $(libcfitsio_la_SOURCES) $(libcfitsio_swapproc_la_SOURCES) \
 	$(tests_test_editcol_SOURCES) $(tests_test_edithdu_SOURCES) \
 	$(tests_test_eval_SOURCES) $(tests_test_fileops_SOURCES) \
 	$(tests_test_find_match_delim_SOURCES) \
-	$(tests_test_getcol_SOURCES) $(tests_test_getcolb_SOURCES) \
-	$(tests_test_getcold_SOURCES) $(tests_test_getcole_SOURCES) \
-	$(tests_test_getcoli_SOURCES) $(tests_test_getcolj_SOURCES) \
-	$(tests_test_getcolk_SOURCES) $(tests_test_getcoll_SOURCES) \
-	$(tests_test_getcols_SOURCES) $(tests_test_getcolsb_SOURCES) \
-	$(tests_test_getcolui_SOURCES) $(tests_test_getcoluj_SOURCES) \
-	$(tests_test_getcoluk_SOURCES) $(tests_test_getkey_SOURCES) \
-	$(tests_test_group_SOURCES) $(tests_test_grparser_SOURCES) \
-	$(tests_test_hcompress_SOURCES) $(tests_test_histo_SOURCES) \
-	$(tests_test_imcompress_SOURCES) \
+	$(tests_test_fitsverify_SOURCES) $(tests_test_getcol_SOURCES) \
+	$(tests_test_getcolb_SOURCES) $(tests_test_getcold_SOURCES) \
+	$(tests_test_getcole_SOURCES) $(tests_test_getcoli_SOURCES) \
+	$(tests_test_getcolj_SOURCES) $(tests_test_getcolk_SOURCES) \
+	$(tests_test_getcoll_SOURCES) $(tests_test_getcols_SOURCES) \
+	$(tests_test_getcolsb_SOURCES) $(tests_test_getcolui_SOURCES) \
+	$(tests_test_getcoluj_SOURCES) $(tests_test_getcoluk_SOURCES) \
+	$(tests_test_getkey_SOURCES) $(tests_test_group_SOURCES) \
+	$(tests_test_grparser_SOURCES) $(tests_test_hcompress_SOURCES) \
+	$(tests_test_histo_SOURCES) $(tests_test_imcompress_SOURCES) \
 	$(tests_test_iraffits_SOURCES) $(tests_test_modkey_SOURCES) \
 	$(tests_test_pliocomp_SOURCES) $(tests_test_putcol_SOURCES) \
 	$(tests_test_putcolb_SOURCES) $(tests_test_putcold_SOURCES) \
@@ -748,16 +755,16 @@ DIST_SOURCES = $(am__libcfitsio_la_SOURCES_DIST) \
 	$(tests_test_edithdu_SOURCES) $(tests_test_eval_SOURCES) \
 	$(tests_test_fileops_SOURCES) \
 	$(tests_test_find_match_delim_SOURCES) \
-	$(tests_test_getcol_SOURCES) $(tests_test_getcolb_SOURCES) \
-	$(tests_test_getcold_SOURCES) $(tests_test_getcole_SOURCES) \
-	$(tests_test_getcoli_SOURCES) $(tests_test_getcolj_SOURCES) \
-	$(tests_test_getcolk_SOURCES) $(tests_test_getcoll_SOURCES) \
-	$(tests_test_getcols_SOURCES) $(tests_test_getcolsb_SOURCES) \
-	$(tests_test_getcolui_SOURCES) $(tests_test_getcoluj_SOURCES) \
-	$(tests_test_getcoluk_SOURCES) $(tests_test_getkey_SOURCES) \
-	$(tests_test_group_SOURCES) $(tests_test_grparser_SOURCES) \
-	$(tests_test_hcompress_SOURCES) $(tests_test_histo_SOURCES) \
-	$(tests_test_imcompress_SOURCES) \
+	$(tests_test_fitsverify_SOURCES) $(tests_test_getcol_SOURCES) \
+	$(tests_test_getcolb_SOURCES) $(tests_test_getcold_SOURCES) \
+	$(tests_test_getcole_SOURCES) $(tests_test_getcoli_SOURCES) \
+	$(tests_test_getcolj_SOURCES) $(tests_test_getcolk_SOURCES) \
+	$(tests_test_getcoll_SOURCES) $(tests_test_getcols_SOURCES) \
+	$(tests_test_getcolsb_SOURCES) $(tests_test_getcolui_SOURCES) \
+	$(tests_test_getcoluj_SOURCES) $(tests_test_getcoluk_SOURCES) \
+	$(tests_test_getkey_SOURCES) $(tests_test_group_SOURCES) \
+	$(tests_test_grparser_SOURCES) $(tests_test_hcompress_SOURCES) \
+	$(tests_test_histo_SOURCES) $(tests_test_imcompress_SOURCES) \
 	$(tests_test_iraffits_SOURCES) $(tests_test_modkey_SOURCES) \
 	$(tests_test_pliocomp_SOURCES) $(tests_test_putcol_SOURCES) \
 	$(tests_test_putcolb_SOURCES) $(tests_test_putcold_SOURCES) \
@@ -1244,6 +1251,7 @@ CLEANFILES = tg123x.kfj include1.tpl include2.tpl test_buffers.fits \
 	test_cfileio.fits test_checksum.fits test_delete.fits \
 	test_editcol.fits test_editcol2.fits test_edithdu.fits \
 	test_edithdu2.fits test_edithdu3.fits test_eval.fits \
+	test_fitsverify_report.txt test_fitsverify.fits \
 	test_getcol.fits test_getcolb.fits test_getcold.fits \
 	test_getcole.fits test_getcoli.fits test_getcolj.fits \
 	test_getcolk.fits test_getcoll.fits test_getcols.fits \
@@ -1271,6 +1279,7 @@ UNIT_TESTS = \
 	tests/test_editcol \
 	tests/test_edithdu \
 	tests/test_eval \
+	tests/test_fitsverify \
 	tests/test_fileops \
 	tests/test_find_match_delim \
 	tests/test_getcol \
@@ -1325,6 +1334,7 @@ tests_test_drvrsmem_SOURCES = tests/test_drvrsmem.c
 tests_test_editcol_SOURCES = tests/test_editcol.c
 tests_test_edithdu_SOURCES = tests/test_edithdu.c
 tests_test_eval_SOURCES = tests/test_eval.c
+tests_test_fitsverify_SOURCES = tests/test_fitsverify.c
 tests_test_fileops_SOURCES = tests/test_fileops.c
 tests_test_find_match_delim_SOURCES = tests/test_find_match_delim.c
 tests_test_getcol_SOURCES = tests/test_getcol.c
@@ -1662,6 +1672,12 @@ tests/test_find_match_delim.$(OBJEXT): tests/$(am__dirstamp) \
 tests/test_find_match_delim$(EXEEXT): $(tests_test_find_match_delim_OBJECTS) $(tests_test_find_match_delim_DEPENDENCIES) $(EXTRA_tests_test_find_match_delim_DEPENDENCIES) tests/$(am__dirstamp)
 	@rm -f tests/test_find_match_delim$(EXEEXT)
 	$(AM_V_CCLD)$(LINK) $(tests_test_find_match_delim_OBJECTS) $(tests_test_find_match_delim_LDADD) $(LIBS)
+tests/test_fitsverify.$(OBJEXT): tests/$(am__dirstamp) \
+	tests/$(DEPDIR)/$(am__dirstamp)
+
+tests/test_fitsverify$(EXEEXT): $(tests_test_fitsverify_OBJECTS) $(tests_test_fitsverify_DEPENDENCIES) $(EXTRA_tests_test_fitsverify_DEPENDENCIES) tests/$(am__dirstamp)
+	@rm -f tests/test_fitsverify$(EXEEXT)
+	$(AM_V_CCLD)$(LINK) $(tests_test_fitsverify_OBJECTS) $(tests_test_fitsverify_LDADD) $(LIBS)
 tests/test_getcol.$(OBJEXT): tests/$(am__dirstamp) \
 	tests/$(DEPDIR)/$(am__dirstamp)
 
@@ -2010,6 +2026,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@tests/$(DEPDIR)/test_eval.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tests/$(DEPDIR)/test_fileops.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tests/$(DEPDIR)/test_find_match_delim.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@tests/$(DEPDIR)/test_fitsverify.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tests/$(DEPDIR)/test_getcol.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tests/$(DEPDIR)/test_getcolb.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@tests/$(DEPDIR)/test_getcold.Po@am__quote@ # am--include-marker
@@ -2990,6 +3007,13 @@ tests/test_eval.log: tests/test_eval$(EXEEXT)
 	--log-file $$b.log --trs-file $$b.trs \
 	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
 	"$$tst" $(AM_TESTS_FD_REDIRECT)
+tests/test_fitsverify.log: tests/test_fitsverify$(EXEEXT)
+	@p='tests/test_fitsverify$(EXEEXT)'; \
+	b='tests/test_fitsverify'; \
+	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
+	--log-file $$b.log --trs-file $$b.trs \
+	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
+	"$$tst" $(AM_TESTS_FD_REDIRECT)
 tests/test_fileops.log: tests/test_fileops$(EXEEXT)
 	@p='tests/test_fileops$(EXEEXT)'; \
 	b='tests/test_fileops'; \
@@ -3646,6 +3670,7 @@ distclean: distclean-am
 	-rm -f tests/$(DEPDIR)/test_eval.Po
 	-rm -f tests/$(DEPDIR)/test_fileops.Po
 	-rm -f tests/$(DEPDIR)/test_find_match_delim.Po
+	-rm -f tests/$(DEPDIR)/test_fitsverify.Po
 	-rm -f tests/$(DEPDIR)/test_getcol.Po
 	-rm -f tests/$(DEPDIR)/test_getcolb.Po
 	-rm -f tests/$(DEPDIR)/test_getcold.Po
@@ -3830,6 +3855,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f tests/$(DEPDIR)/test_eval.Po
 	-rm -f tests/$(DEPDIR)/test_fileops.Po
 	-rm -f tests/$(DEPDIR)/test_find_match_delim.Po
+	-rm -f tests/$(DEPDIR)/test_fitsverify.Po
 	-rm -f tests/$(DEPDIR)/test_getcol.Po
 	-rm -f tests/$(DEPDIR)/test_getcolb.Po
 	-rm -f tests/$(DEPDIR)/test_getcold.Po

--- a/tests/test_fitsverify.c
+++ b/tests/test_fitsverify.c
@@ -1,0 +1,108 @@
+/*
+ * Tests for the fitsverify utility (utilities/fvrf_*.c).
+ *
+ * Two kinds of test live here.  Routines that can be driven on their own -
+ * the keyword value parsers, the error reporting - are called in process:
+ * their source file is #included, and the handful of symbols the rest of
+ * fitsverify would have provided are stubbed below.  Defects that only show
+ * up on a whole file are exercised by writing that file and running the
+ * fitsverify binary over it.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/wait.h>
+
+#include "fitsio.h"
+#include "test_macros.h"
+
+/* Globals that utilities/ftverify.c owns in the real program. */
+int prhead = 0;
+int testdata = 1;
+int testfill = 1;
+int testcsum = 1;
+int totalhdu = 0;
+int err_report = 0;
+int heasarc_conv = 1;
+int testhierarch = 0;
+int prstat = 0;
+
+/* Only reached after MAXERRORS reports, which these tests stay well under. */
+void update_parfile(int nerr, int nwrn) { (void)nerr; (void)nwrn; }
+void close_report(FILE *out) { (void)out; }
+
+#include "../utilities/fvrf_key.c"
+#include "../utilities/fvrf_misc.c"
+
+/*--------------------------------------------------------------------------
+ * get_cmp: complex keyword values (utilities/fvrf_key.c)
+ *------------------------------------------------------------------------*/
+
+/* Parse a complex keyword value and return the accumulated error mask. */
+static unsigned long
+parse_cmp(const char *value, char *kvalue, kwdtyp *ktype)
+{
+	char card[FLEN_CARD];
+	char *p = card;
+	unsigned long stat = 0;
+
+	memset(card, 0, sizeof(card));
+	strcpy(card, value);
+	kvalue[0] = '\0';
+	*ktype = UNKNOWN;
+	get_cmp(&p, kvalue, ktype, &stat);
+	return stat;
+}
+
+static void
+test_complex_keyword_values(void)
+{
+	char kvalue[FLEN_CARD];
+	kwdtyp ktype;
+	unsigned long stat;
+
+	/* A well formed integer complex value. */
+	stat = parse_cmp("(1,2)", kvalue, &ktype);
+	fail_if(stat != 0);
+	fail_if(ktype != CMI_KEY);
+
+	/* A well formed floating point complex value. */
+	stat = parse_cmp("(1.5,-2.5)", kvalue, &ktype);
+	fail_if(stat != 0);
+	fail_if(ktype != CMF_KEY);
+
+	/*
+	 * No comma: there is no imaginary part to analyse.  This used to
+	 * write through a NULL pr_end and read through an uninitialised
+	 * pi_beg, so the process died here.
+	 */
+	stat = parse_cmp("(1 2)", kvalue, &ktype);
+	fail_if(!(stat & NO_COMMA));
+
+	/* No comma and no closing paren either. */
+	stat = parse_cmp("(1 2", kvalue, &ktype);
+	fail_if(!(stat & NO_COMMA));
+	fail_if(!(stat & NO_TRAIL_PAREN));
+
+	/* Nothing but the opening paren. */
+	stat = parse_cmp("(", kvalue, &ktype);
+	fail_if(!(stat & NO_COMMA));
+
+	/* A comma but no closing paren still gets both parts analysed. */
+	stat = parse_cmp("(1,2", kvalue, &ktype);
+	fail_if(stat & NO_COMMA);
+	fail_if(!(stat & NO_TRAIL_PAREN));
+
+	/* Too many commas is reported, and must not crash. */
+	stat = parse_cmp("(1,2,3)", kvalue, &ktype);
+	fail_if(!(stat & TOO_MANY_COMMA));
+}
+
+int
+main(void)
+{
+	test_complex_keyword_values();
+	return 0;
+}

--- a/tests/test_fitsverify.c
+++ b/tests/test_fitsverify.c
@@ -646,6 +646,88 @@ test_error_stack_report(void)
 	fail_if(count_lines_with(lines, nlines, "second message") != 1);
 }
 
+/*--------------------------------------------------------------------------
+ * test_bin_ext and print_summary: indexing naxes[] (utilities/fvrf_head.c)
+ *------------------------------------------------------------------------*/
+
+/*
+ * An image extension whose XTENSION value starts with, but is not,
+ * BINTABLE.  CFITSIO compares the whole value string and reads it as an
+ * image; init_hdu compares the raw card text with strncmp(p,"BINTABLE",8)
+ * and hands it to the binary table checks, carrying an image's NAXIS.
+ * naxis1 < 0 asks for NAXIS = 0.
+ */
+static void
+write_image_named_bintable(long naxis1)
+{
+	long n;
+	FILE *fp = open_testfile(&n);
+	char card[81];
+
+	put_card(fp, &n, "XTENSION= 'BINTABLEX'");
+	put_card(fp, &n, "BITPIX  =                    8");
+	if (naxis1 < 0) {
+		put_card(fp, &n, "NAXIS   =                    0");
+	} else {
+		put_card(fp, &n, "NAXIS   =                    1");
+		snprintf(card, sizeof(card), "NAXIS1  = %20ld", naxis1);
+		put_card(fp, &n, card);
+	}
+	put_card(fp, &n, "PCOUNT  =                    0");
+	put_card(fp, &n, "GCOUNT  =                    1");
+	put_card(fp, &n, "END");
+	pad_block(fp, &n);
+
+	if (naxis1 > 0)
+		put_bytes(fp, &n, 'x', naxis1);
+	close_testfile(fp, &n);
+}
+
+/* A real tile compressed image, which is a binary table on disk. */
+static void
+write_compressed_image(void)
+{
+	fitsfile *fptr;
+	int status = 0;
+	long naxes[2] = { 8, 4 };
+	short pix[32];
+	int i;
+
+	remove(TESTFILE);
+	fits_create_file(&fptr, TESTFILE, &status);
+	fits_create_img(fptr, SHORT_IMG, 0, NULL, &status);
+	fits_set_compression_type(fptr, RICE_1, &status);
+	fits_create_img(fptr, SHORT_IMG, 2, naxes, &status);
+	for (i = 0; i < 32; i++)
+		pix[i] = (short)i;
+	fits_write_img(fptr, TSHORT, 1, 32, pix, &status);
+	fits_close_file(fptr, &status);
+	fail_if(status != 0);
+}
+
+static void
+test_binary_table_naxes(void)
+{
+	/*
+	 * naxes holds exactly naxis elements, and is left unset when NAXIS is
+	 * 0 - in which case it used to keep the previous HDU's freed pointer,
+	 * since the FitsHdu is reused across the HDU loop.
+	 */
+	write_image_named_bintable(-1);
+	check_no_crash("a NAXIS = 0 extension named BINTABLEX");
+
+	write_image_named_bintable(10);
+	check_no_crash("a NAXIS = 1 extension named BINTABLEX");
+
+	/*
+	 * A genuine tile compressed image must still be recognised and
+	 * verified as the binary table it is.
+	 */
+	write_compressed_image();
+	fail_if(check_no_crash("a tile compressed image") != 0);
+	fail_if(!report_has("Binary Table"));
+}
+
 int
 main(void)
 {
@@ -664,6 +746,7 @@ main(void)
 	test_first_card_keyword_index();
 	test_ascii_column_template();
 	test_truncated_ascii_table();
+	test_binary_table_naxes();
 
 	remove(TESTFILE);
 	remove(REPORT);

--- a/tests/test_fitsverify.c
+++ b/tests/test_fitsverify.c
@@ -341,6 +341,50 @@ test_bit_column_report(void)
 	check_bit_column(3996);
 }
 
+/*--------------------------------------------------------------------------
+ * init_hdu: the card number printed for the first cards of an HDU
+ * (utilities/fvrf_head.c)
+ *------------------------------------------------------------------------*/
+
+/* An extension whose XTENSION value is an integer rather than a string. */
+static void
+write_bad_xtension_table(void)
+{
+	long n;
+	FILE *fp = open_testfile(&n);
+
+	put_card(fp, &n, "XTENSION=                 1234");
+	put_card(fp, &n, "BITPIX  =                    8");
+	put_card(fp, &n, "NAXIS   =                    2");
+	put_card(fp, &n, "NAXIS1  =                   10");
+	put_card(fp, &n, "NAXIS2  =                    1");
+	put_card(fp, &n, "PCOUNT  =                    0");
+	put_card(fp, &n, "GCOUNT  =                    1");
+	put_card(fp, &n, "TFIELDS =                    1");
+	put_card(fp, &n, "TFORM1  = '10A     '");
+	put_card(fp, &n, "TTYPE1  = 'COL1    '");
+	put_card(fp, &n, "END");
+	pad_block(fp, &n);
+
+	put_bytes(fp, &n, 'x', 10);
+	close_testfile(fp, &n);
+}
+
+static void
+test_first_card_keyword_index(void)
+{
+	/*
+	 * init_hdu parses the first cards of an HDU into an automatic FitsKey
+	 * whose kindex was never assigned, so this diagnostic used to carry
+	 * whatever happened to be on the stack.  XTENSION is card 1.
+	 */
+	write_bad_xtension_table();
+	check_no_crash("an XTENSION value that is not a string");
+
+	fail_if(count_in_report(
+	    "Keyword #1, XTENSION: \"1234\" is not a string.") != 1);
+}
+
 int
 main(void)
 {
@@ -355,6 +399,7 @@ main(void)
 
 	test_tform_substring_width();
 	test_bit_column_report();
+	test_first_card_keyword_index();
 
 	remove(TESTFILE);
 	remove(REPORT);

--- a/tests/test_fitsverify.c
+++ b/tests/test_fitsverify.c
@@ -385,6 +385,73 @@ test_first_card_keyword_index(void)
 	    "Keyword #1, XTENSION: \"1234\" is not a string.") != 1);
 }
 
+/*--------------------------------------------------------------------------
+ * test_agap: the column template (utilities/fvrf_data.c)
+ *------------------------------------------------------------------------*/
+
+/* A single column ASCII table with the given row length, start and format. */
+static void
+write_ascii_table(long naxis1, long tbcol, const char *tform)
+{
+	long n;
+	FILE *fp = open_testfile(&n);
+	char card[81];
+
+	put_card(fp, &n, "XTENSION= 'TABLE   '");
+	put_card(fp, &n, "BITPIX  =                    8");
+	put_card(fp, &n, "NAXIS   =                    2");
+	snprintf(card, sizeof(card), "NAXIS1  = %20ld", naxis1);
+	put_card(fp, &n, card);
+	put_card(fp, &n, "NAXIS2  =                    1");
+	put_card(fp, &n, "PCOUNT  =                    0");
+	put_card(fp, &n, "GCOUNT  =                    1");
+	put_card(fp, &n, "TFIELDS =                    1");
+	put_card(fp, &n, "TTYPE1  = 'COL1    '");
+	snprintf(card, sizeof(card), "TBCOL1  = %20ld", tbcol);
+	put_card(fp, &n, card);
+	snprintf(card, sizeof(card), "TFORM1  = '%-8s'", tform);
+	put_card(fp, &n, card);
+	put_card(fp, &n, "END");
+	pad_block(fp, &n);
+
+	put_bytes(fp, &n, '1', naxis1);
+	close_testfile(fp, &n);
+}
+
+static void
+check_ascii_table(long naxis1, long tbcol, const char *tform)
+{
+	char what[96];
+
+	snprintf(what, sizeof(what), "NAXIS1=%ld TBCOL1=%ld TFORM1=%s",
+		 naxis1, tbcol, tform);
+	write_ascii_table(naxis1, tbcol, tform);
+	check_no_crash(what);
+}
+
+static void
+test_ascii_column_template(void)
+{
+	/*
+	 * test_agap marks which bytes of a row belong to a column in a NAXIS1
+	 * long template, from TBCOLn and TFORMn.  Nothing bounded those
+	 * writes, and CFITSIO skips its own TBCOLn range checks when the row
+	 * length is zero.
+	 */
+
+	/* A well formed table still verifies. */
+	check_ascii_table(10, 1, "A10");
+
+	/* Zero row length: the template has no room for any column at all. */
+	check_ascii_table(0, 1, "A20");
+
+	/* ... and the column start is unchecked in that case. */
+	check_ascii_table(0, 100000000, "A20");
+
+	/* A zero column start would write below the template. */
+	check_ascii_table(0, 0, "A20");
+}
+
 int
 main(void)
 {
@@ -400,6 +467,7 @@ main(void)
 	test_tform_substring_width();
 	test_bit_column_report();
 	test_first_card_keyword_index();
+	test_ascii_column_template();
 
 	remove(TESTFILE);
 	remove(REPORT);

--- a/tests/test_fitsverify.c
+++ b/tests/test_fitsverify.c
@@ -255,6 +255,92 @@ test_tform_substring_width(void)
 	}
 }
 
+/*--------------------------------------------------------------------------
+ * iterdata: the bit column justification report (utilities/fvrf_data.c)
+ *------------------------------------------------------------------------*/
+
+/* Count occurrences of a string in the report. */
+static int
+count_in_report(const char *needle)
+{
+	FILE *fp = fopen(REPORT, "r");
+	char line[4096];
+	int nfound = 0;
+
+	fail_if(fp == NULL);
+	while (fgets(line, sizeof(line), fp) != NULL) {
+		char *p = line;
+
+		while ((p = strstr(p, needle)) != NULL) {
+			nfound++;
+			p += strlen(needle);
+		}
+	}
+	fclose(fp);
+	return nfound;
+}
+
+/*
+ * A binary table holding a single X column of nbits bits.  nbits is chosen
+ * by the caller so that it is not a multiple of 8, which leaves fill bits in
+ * the last byte; the data is all ones, so those fill bits are set and the
+ * "not left justified" report is produced.
+ */
+static void
+write_bit_column_table(int nbits)
+{
+	long n;
+	FILE *fp = open_testfile(&n);
+	long nbytes = (nbits + 7) / 8;
+	char card[81];
+
+	put_card(fp, &n, "XTENSION= 'BINTABLE'");
+	put_card(fp, &n, "BITPIX  =                    8");
+	put_card(fp, &n, "NAXIS   =                    2");
+	snprintf(card, sizeof(card), "NAXIS1  = %20ld", nbytes);
+	put_card(fp, &n, card);
+	put_card(fp, &n, "NAXIS2  =                    1");
+	put_card(fp, &n, "PCOUNT  =                    0");
+	put_card(fp, &n, "GCOUNT  =                    1");
+	put_card(fp, &n, "TFIELDS =                    1");
+	snprintf(card, sizeof(card), "TFORM1  = '%dX'", nbits);
+	put_card(fp, &n, card);
+	put_card(fp, &n, "TTYPE1  = 'BITS    '");
+	put_card(fp, &n, "END");
+	pad_block(fp, &n);
+
+	put_bytes(fp, &n, 0xff, nbytes);
+	close_testfile(fp, &n);
+}
+
+static void
+check_bit_column(int nbits)
+{
+	char what[64];
+
+	snprintf(what, sizeof(what), "a %dX column", nbits);
+	write_bit_column_table(nbits);
+	check_no_crash(what);
+
+	fail_if(count_in_report("is not left justified.") != 1);
+	/*
+	 * errmes is 256 bytes and each element costs five of them, so a
+	 * bounded report can never hold much more than fifty.  An unbounded
+	 * one prints every byte of the column.
+	 */
+	fail_if(count_in_report("0x") > 64);
+}
+
+static void
+test_bit_column_report(void)
+{
+	/* 100 bits in a 13 byte row: the report fits in errmes. */
+	check_bit_column(100);
+
+	/* 3996 bits in a 500 byte row: it does not. */
+	check_bit_column(3996);
+}
+
 int
 main(void)
 {
@@ -268,6 +354,7 @@ main(void)
 	}
 
 	test_tform_substring_width();
+	test_bit_column_report();
 
 	remove(TESTFILE);
 	remove(REPORT);

--- a/tests/test_fitsverify.c
+++ b/tests/test_fitsverify.c
@@ -530,10 +530,127 @@ test_truncated_ascii_table(void)
 	fail_if(report_has("non-ASCII"));
 }
 
+/*--------------------------------------------------------------------------
+ * wrtserr: dumping the CFITSIO error stack (utilities/fvrf_misc.c)
+ *------------------------------------------------------------------------*/
+
+/*
+ * Leave a known pattern on the stack where the next call's locals will sit,
+ * so that a read past the end of one of them shows up in the report instead
+ * of depending on what happened to be there.
+ */
+static void
+poison_stack(void)
+{
+	volatile char junk[8192];
+	size_t i;
+
+	for (i = 0; i < sizeof(junk); i++)
+		junk[i] = 'Z';
+}
+
+/* Dump the whole error stack through wrtserr into the report. */
+static void
+dump_error_stack(void)
+{
+	FILE *out = fopen(REPORT, "w");
+	int status = 0;
+
+	fail_if(out == NULL);
+	reset_err_wrn();
+	poison_stack();
+	wrtserr(out, "test: ", &status, 1);
+	fail_if(status != 0);
+	fclose(out);
+}
+
+/* Read the report back, one line at a time, newline stripped. */
+static int
+read_report_lines(char lines[][256], int maxlines)
+{
+	FILE *fp = fopen(REPORT, "r");
+	int n = 0;
+
+	fail_if(fp == NULL);
+	while (n < maxlines && fgets(lines[n], 256, fp) != NULL) {
+		size_t len = strlen(lines[n]);
+
+		while (len > 0 && (lines[n][len - 1] == '\n' ||
+				   lines[n][len - 1] == '\r'))
+			lines[n][--len] = '\0';
+		n++;
+	}
+	fclose(fp);
+	return n;
+}
+
+static int
+count_lines_with(char lines[][256], int nlines, const char *needle)
+{
+	int i, n = 0;
+
+	for (i = 0; i < nlines; i++)
+		if (strstr(lines[i], needle) != NULL)
+			n++;
+	return n;
+}
+
+static void
+test_error_stack_report(void)
+{
+	char lines[64][256];
+	char msg[FLEN_ERRMSG];
+	int nlines, i;
+
+	/* The ordinary case: a couple of messages, printed in order. */
+	fits_clear_errmsg();
+	fits_write_errmsg("first message");
+	fits_write_errmsg("second message");
+	dump_error_stack();
+	nlines = read_report_lines(lines, 64);
+	fail_if(count_lines_with(lines, nlines, "first message") != 1);
+	fail_if(count_lines_with(lines, nlines, "second message") != 1);
+	fail_if(count_lines_with(lines, nlines, "ZZZ") != 0);
+
+	/*
+	 * More messages than wrtserr keeps rows for.  It stops reading at 20
+	 * and used to print one row past the end of its array.  CFITSIO's own
+	 * stack holds up to 25 (errmsgsiz), so this is reachable.
+	 */
+	fits_clear_errmsg();
+	for (i = 0; i < 25; i++) {
+		snprintf(msg, sizeof(msg), "wrtserr test message %02d", i);
+		fits_write_errmsg(msg);
+	}
+	dump_error_stack();
+	nlines = read_report_lines(lines, 64);
+	fail_if(count_lines_with(lines, nlines, "wrtserr test message") != 20);
+	fail_if(count_lines_with(lines, nlines, "ZZZ") != 0);
+	/* The report ends with the blank line a stack dump always emits. */
+	fail_if(nlines < 2);
+	fail_if(strspn(lines[nlines - 1], " \t") != strlen(lines[nlines - 1]));
+
+	/*
+	 * A message of the maximum length CFITSIO can hand back.  It used to
+	 * be written into an 80 byte row, so its terminator landed in the
+	 * next row and truncated the message stored there.
+	 */
+	fits_clear_errmsg();
+	memset(msg, 'a', FLEN_ERRMSG - 1);
+	msg[FLEN_ERRMSG - 1] = '\0';
+	fits_write_errmsg(msg);
+	fits_write_errmsg("second message");
+	dump_error_stack();
+	nlines = read_report_lines(lines, 64);
+	fail_if(count_lines_with(lines, nlines, "aaaaaaaaaa") != 1);
+	fail_if(count_lines_with(lines, nlines, "second message") != 1);
+}
+
 int
 main(void)
 {
 	test_complex_keyword_values();
+	test_error_stack_report();
 
 	if (access(FITSVERIFY, X_OK) != 0) {
 		fprintf(stderr,

--- a/tests/test_fitsverify.c
+++ b/tests/test_fitsverify.c
@@ -452,6 +452,84 @@ test_ascii_column_template(void)
 	check_ascii_table(0, 0, "A20");
 }
 
+/*--------------------------------------------------------------------------
+ * test_agap: reading a truncated table (utilities/fvrf_data.c)
+ *------------------------------------------------------------------------*/
+
+static int
+report_has(const char *needle)
+{
+	return count_in_report(needle) > 0;
+}
+
+/*
+ * A 500 row ASCII table.  The first row holds bytes that are not ASCII text,
+ * so the data scan has something to find; every other row is ordinary text.
+ * If truncate_it is set the last 2880 byte block is dropped, which cuts the
+ * table data short while the header still claims all 500 rows.
+ */
+static void
+write_ascii_data_table(int truncate_it)
+{
+	long n;
+	FILE *fp = open_testfile(&n);
+	long datastart;
+	long i;
+
+	put_card(fp, &n, "XTENSION= 'TABLE   '");
+	put_card(fp, &n, "BITPIX  =                    8");
+	put_card(fp, &n, "NAXIS   =                    2");
+	put_card(fp, &n, "NAXIS1  =                   10");
+	put_card(fp, &n, "NAXIS2  =                  500");
+	put_card(fp, &n, "PCOUNT  =                    0");
+	put_card(fp, &n, "GCOUNT  =                    1");
+	put_card(fp, &n, "TFIELDS =                    1");
+	put_card(fp, &n, "TTYPE1  = 'COL1    '");
+	put_card(fp, &n, "TBCOL1  =                    1");
+	put_card(fp, &n, "TFORM1  = 'A10     '");
+	put_card(fp, &n, "END");
+	pad_block(fp, &n);
+
+	datastart = n;
+	put_bytes(fp, &n, 0xff, 10);
+	for (i = 10; i < 500 * 10; i++) {
+		fputc('0' + (int)(i % 10), fp);
+		n++;
+	}
+	close_testfile(fp, &n);
+
+	if (truncate_it) {
+		fail_if(n - 2880 <= datastart);
+		fail_if(truncate(TESTFILE, n - 2880) != 0);
+	}
+}
+
+static void
+test_truncated_ascii_table(void)
+{
+	/*
+	 * Control: the whole file is there, so the bad bytes in row 1 are
+	 * read and have to be reported, all ten of them.
+	 */
+	write_ascii_data_table(0);
+	check_no_crash("an ASCII table holding non-text bytes");
+	fail_if(!report_has("contains non-ASCII characters."));
+	fail_if(!report_has(
+	    "This ASCII table contains 10 non-ASCII-text characters"));
+
+	/*
+	 * Truncated: the rows cannot be read at all, so the data scan has
+	 * nothing to say about them.  test_agap used to report the failed
+	 * read and then scan the buffer anyway, describing memory rather
+	 * than the file.
+	 */
+	write_ascii_data_table(1);
+	fail_if(check_no_crash("a truncated ASCII table") == 0);
+	if (report_has("non-ASCII"))
+		fprintf(stderr, "data scanned past the end of the file\n");
+	fail_if(report_has("non-ASCII"));
+}
+
 int
 main(void)
 {
@@ -468,6 +546,7 @@ main(void)
 	test_bit_column_report();
 	test_first_card_keyword_index();
 	test_ascii_column_template();
+	test_truncated_ascii_table();
 
 	remove(TESTFILE);
 	remove(REPORT);

--- a/tests/test_fitsverify.c
+++ b/tests/test_fitsverify.c
@@ -100,9 +100,176 @@ test_complex_keyword_values(void)
 	fail_if(!(stat & TOO_MANY_COMMA));
 }
 
+/*--------------------------------------------------------------------------
+ * Driving the fitsverify binary over a file built for the purpose
+ *------------------------------------------------------------------------*/
+
+#define FITSVERIFY	"./fitsverify"
+#define TESTFILE	"test_fitsverify.fits"
+#define REPORT		"test_fitsverify_report.txt"
+
+/* Write one 80 column card, blank padded. */
+static void
+put_card(FILE *fp, long *nbytes, const char *card)
+{
+	char buf[81];
+
+	snprintf(buf, sizeof(buf), "%-80.80s", card);
+	fwrite(buf, 1, 80, fp);
+	*nbytes += 80;
+}
+
+/* Write count copies of one byte. */
+static void
+put_bytes(FILE *fp, long *nbytes, int byte, long count)
+{
+	long i;
+
+	for (i = 0; i < count; i++) {
+		fputc(byte, fp);
+		(*nbytes)++;
+	}
+}
+
+/* Pad with blanks out to the next 2880 byte block. */
+static void
+pad_block(FILE *fp, long *nbytes)
+{
+	while (*nbytes % 2880) {
+		fputc(' ', fp);
+		(*nbytes)++;
+	}
+}
+
+/* Start TESTFILE with an empty primary array that allows extensions. */
+static FILE *
+open_testfile(long *nbytes)
+{
+	FILE *fp = fopen(TESTFILE, "wb");
+
+	fail_if(fp == NULL);
+	*nbytes = 0;
+	put_card(fp, nbytes, "SIMPLE  =                    T");
+	put_card(fp, nbytes, "BITPIX  =                    8");
+	put_card(fp, nbytes, "NAXIS   =                    0");
+	put_card(fp, nbytes, "EXTEND  =                    T");
+	put_card(fp, nbytes, "END");
+	pad_block(fp, nbytes);
+	return fp;
+}
+
+static void
+close_testfile(FILE *fp, long *nbytes)
+{
+	pad_block(fp, nbytes);
+	fail_if(fclose(fp) != 0);
+}
+
+/*
+ * Run fitsverify on TESTFILE and return the raw wait status.  fork/exec
+ * rather than system(), so that a fatal signal shows up as WIFSIGNALED
+ * instead of being flattened into the shell's 128+n exit status.
+ */
+static int
+run_fitsverify(void)
+{
+	pid_t pid;
+	int st = 0;
+
+	pid = fork();
+	fail_if(pid < 0);
+	if (pid == 0) {
+		if (freopen(REPORT, "w", stdout) == NULL)
+			_exit(126);
+		if (dup2(fileno(stdout), fileno(stderr)) < 0)
+			_exit(126);
+		execl(FITSVERIFY, FITSVERIFY, TESTFILE, (char *)NULL);
+		_exit(127);
+	}
+	fail_if(waitpid(pid, &st, 0) != pid);
+	return st;
+}
+
+/* Verify the run finished on its own terms, and return its exit status. */
+static int
+check_no_crash(const char *what)
+{
+	int st = run_fitsverify();
+
+	if (WIFSIGNALED(st))
+		fprintf(stderr, "fitsverify died on %s with signal %d\n",
+			what, WTERMSIG(st));
+	fail_if(WIFSIGNALED(st));
+	/* 126/127: the binary could not be run at all. */
+	fail_if(WEXITSTATUS(st) == 126 || WEXITSTATUS(st) == 127);
+	return WEXITSTATUS(st);
+}
+
+/*--------------------------------------------------------------------------
+ * test_bin_ext: the "rAw" TFORM check (utilities/fvrf_head.c)
+ *------------------------------------------------------------------------*/
+
+/* A one column binary table with the given TFORM. */
+static void
+write_bintable_column(const char *tform)
+{
+	long n;
+	FILE *fp = open_testfile(&n);
+	char card[81];
+
+	put_card(fp, &n, "XTENSION= 'BINTABLE'");
+	put_card(fp, &n, "BITPIX  =                    8");
+	put_card(fp, &n, "NAXIS   =                    2");
+	put_card(fp, &n, "NAXIS1  =                   10");
+	put_card(fp, &n, "NAXIS2  =                    1");
+	put_card(fp, &n, "PCOUNT  =                    0");
+	put_card(fp, &n, "GCOUNT  =                    1");
+	put_card(fp, &n, "TFIELDS =                    1");
+	snprintf(card, sizeof(card), "TFORM1  = '%-8s'", tform);
+	put_card(fp, &n, card);
+	put_card(fp, &n, "TTYPE1  = 'COL1    '");
+	put_card(fp, &n, "END");
+	pad_block(fp, &n);
+
+	put_bytes(fp, &n, 'x', 10);
+	close_testfile(fp, &n);
+}
+
+static void
+test_tform_substring_width(void)
+{
+	/*
+	 * The check divides the repeat count by the substring width taken
+	 * straight from the TFORM value, and only guards it with isdigit(),
+	 * which admits '0'.  A width of zero used to raise SIGFPE.
+	 */
+	static const char *tforms[] = { "10A0", "0A0", "3A0", "10A", "10A5" };
+	size_t i;
+
+	for (i = 0; i < sizeof(tforms) / sizeof(tforms[0]); i++) {
+		char what[64];
+
+		snprintf(what, sizeof(what), "TFORM '%s'", tforms[i]);
+		write_bintable_column(tforms[i]);
+		check_no_crash(what);
+	}
+}
+
 int
 main(void)
 {
 	test_complex_keyword_values();
+
+	if (access(FITSVERIFY, X_OK) != 0) {
+		fprintf(stderr,
+			"%s has not been built; skipping the tests "
+			"that need it\n", FITSVERIFY);
+		return 0;
+	}
+
+	test_tform_substring_width();
+
+	remove(TESTFILE);
+	remove(REPORT);
 	return 0;
 }

--- a/tests/tests.am
+++ b/tests/tests.am
@@ -6,6 +6,7 @@ UNIT_TESTS = \
 	tests/test_editcol \
 	tests/test_edithdu \
 	tests/test_eval \
+	tests/test_fitsverify \
 	tests/test_fileops \
 	tests/test_find_match_delim \
 	tests/test_getcol \
@@ -64,6 +65,7 @@ tests_test_drvrsmem_SOURCES = tests/test_drvrsmem.c
 tests_test_editcol_SOURCES = tests/test_editcol.c
 tests_test_edithdu_SOURCES = tests/test_edithdu.c
 tests_test_eval_SOURCES = tests/test_eval.c
+tests_test_fitsverify_SOURCES = tests/test_fitsverify.c
 tests_test_fileops_SOURCES = tests/test_fileops.c
 tests_test_find_match_delim_SOURCES = tests/test_find_match_delim.c
 tests_test_getcol_SOURCES = tests/test_getcol.c
@@ -125,6 +127,8 @@ CLEANFILES += \
 	test_edithdu2.fits \
 	test_edithdu3.fits \
 	test_eval.fits \
+	test_fitsverify_report.txt \
+	test_fitsverify.fits \
 	test_getcol.fits \
 	test_getcolb.fits \
 	test_getcold.fits \

--- a/utilities/fvrf_data.c
+++ b/utilities/fvrf_data.c
@@ -542,8 +542,12 @@ data_end:
 
     /* bit column working space */
     static unsigned char bdata;
+    /* trailing text of the bit justification report, appended after however
+       many column bytes fit in errmes */
+#define NOTLEFTJUST "is not left justified."
+    size_t nchar;
 
-    int i; 
+    int i;
     long j,k,l;
     long nelem;
 
@@ -589,14 +593,25 @@ data_end:
                j = (k+1)*repeat[i];
                bdata = (unsigned char)data[j]; 
                if( bdata & usrpt->mask[i] ) { 
-                  sprintf(errmes, 
-                    "Row #%ld, and Column #%d: X vector ", firstn+k, 
-                      fits_iter_get_colnum(&(iter_col[i]))); 
+                  snprintf(errmes, sizeof(errmes),
+                    "Row #%ld, and Column #%d: X vector ", firstn+k,
+                      fits_iter_get_colnum(&(iter_col[i])));
+                  nchar = strlen(errmes);
                   for (l = 1; l<= repeat[i]; l++) {
-                     sprintf(comm, "0x%02x ", (unsigned char) data[k*repeat[i]+l]);
-                     strcat(errmes,comm); 
+                     /* repeat[i] is the width of the column in bytes and can
+                        be arbitrarily large, so stop before errmes fills up,
+                        leaving room for the elision and the trailing text */
+                     if(nchar + 5 + 4 + strlen(NOTLEFTJUST) >= sizeof(errmes)) {
+                        strcpy(errmes+nchar,"... ");
+                        nchar += 4;
+                        break;
+                     }
+                     snprintf(comm, sizeof(comm), "0x%02x ",
+                        (unsigned char) data[k*repeat[i]+l]);
+                     strcpy(errmes+nchar,comm);
+                     nchar += strlen(comm);
                   }
-                  strcat(errmes,"is not left justified."); 
+                  strcpy(errmes+nchar,NOTLEFTJUST);
                   wrterr(usrpt->out,errmes,2);
                   strcpy(errmes,
           "             (Other rows may have errors).");

--- a/utilities/fvrf_data.c
+++ b/utilities/fvrf_data.c
@@ -773,16 +773,16 @@ void test_agap(fitsfile *infits, 	/* input fits file   */
     unsigned char *data;
     int *temp;
     unsigned char *p;
-    LONGLONG i, j;
-    int k, m, t;
+    LONGLONG i, j, m, t;
+    int k;
     long firstrow = 1;
     long ntodo;
     long nerr = 0;
     int status = 0;
-    char keyname[9];
+    char keyname[FLEN_KEYWORD];
     char tform[FLEN_VALUE], comment[256];
     int typecode, decimals;
-    long width, tbcol;
+    long width = 0, tbcol = 0;
     nerr = 0;
 
     if(hduptr->hdutype != ASCII_TBL) return;
@@ -801,15 +801,31 @@ void test_agap(fitsfile *infits, 	/* input fits file   */
 
     temp = (int*)malloc(rowlen * sizeof(int));
     for (m = 0; m<rowlen; m++ ) temp[m]=0;
-    for (k = 1; k<=ncols; k++ ) { 
-	sprintf(keyname, "TFORM%d",k);
-	fits_read_key_str(infits, keyname, tform, comment, &status);
+    for (k = 1; k<=ncols; k++ ) {
+        /* Each column stands on its own: a failed read must not leave the
+           previous column's width and start behind for this one to use. The
+           validity of TFORMn and TBCOLn is reported by test_asc_ext. */
+        status = 0;
+        width = 0;
+        tbcol = 0;
+	snprintf(keyname, sizeof(keyname), "TFORM%d",k);
+	if (fits_read_key_str(infits, keyname, tform, comment, &status))
+	    continue;
 	if (fits_ascii_tform(tform, &typecode, &width, &decimals, &status))
-	    wrtferr(out,"",&status,1);
-	sprintf(keyname, "TBCOL%d",k);
-	fits_read_key_lng(infits, keyname, &tbcol, comment, &status);
-	for (t = tbcol; t < tbcol+width; t++) temp[t-1]=1;
+	    continue;
+	snprintf(keyname, sizeof(keyname), "TBCOL%d",k);
+	if (fits_read_key_lng(infits, keyname, &tbcol, comment, &status))
+	    continue;
+        /* TBCOLn and TFORMn are header values and are not necessarily
+           consistent with NAXIS1, so keep the template writes inside the
+           row that was allocated for them.  A zero NAXIS1 in particular is
+           not rejected by CFITSIO, which skips its TBCOLn range checks when
+           the row length is zero. */
+	if(tbcol < 0) tbcol = 0;
+	for (t = (tbcol > 1 ? tbcol : 1); t <= rowlen && t - tbcol < width; t++)
+	    temp[t-1]=1;
     }
+    status = 0;
 
     i = nrows; 
     while( i > 0) { 

--- a/utilities/fvrf_data.c
+++ b/utilities/fvrf_data.c
@@ -835,10 +835,13 @@ void test_agap(fitsfile *infits, 	/* input fits file   */
 	    ntodo = i; 
         
         p = data;
-        if(fits_read_tblbytes(infits,firstrow,1, rowlen*ntodo, 
-	    data, &status)){  
+        if(fits_read_tblbytes(infits,firstrow,1, rowlen*ntodo,
+	    data, &status)){
 	    wrtferr(out,"",&status,1);
-        } 
+	    /* the rows were not read, so there is nothing to scan: going on
+	       would report on whatever the buffer happened to hold */
+	    break;
+        }
         for (j = 0; j<rowlen*ntodo; j++ ) { 
             if(!isascii(*p))  {
 	        if(!nerr) { 

--- a/utilities/fvrf_head.c
+++ b/utilities/fvrf_head.c
@@ -322,6 +322,7 @@ void init_hdu(fitsfile *infits, 	/* input fits file   */
          wrtferr(out,"",&status,2);
     check_fixed_int(cards[2], out);
 
+    hduptr->naxes = NULL;
     if(hduptr->naxis!=0)  
 	 hduptr->naxes = (LONGLONG *)malloc(hduptr->naxis*sizeof(LONGLONG));
     for (i = 0; i < hduptr->naxis; i++) hduptr->naxes[i] = -1;
@@ -2368,7 +2369,13 @@ void test_bin_ext(fitsfile *infits, 	/* input fits file   */
     } 
 
     /* Check THEAP keyword */   
-    hduptr->heap = (hduptr->naxes[0]) * (hduptr->naxes[1]);
+    /* naxes holds exactly naxis elements, and a conforming table has
+       NAXIS = 2.  This is reached with fewer for a malformed header, e.g.
+       an image extension whose XTENSION value starts with "BINTABLE". */
+    if(hduptr->naxis >= 2)
+        hduptr->heap = (hduptr->naxes[0]) * (hduptr->naxes[1]);
+    else
+        hduptr->heap = 0;
     strcpy(temp,"THEAP");
     key_match(tmpkwds,numusrkey,&ptemp,1,&k,&n);  
     if(k > -1) { 
@@ -3142,6 +3149,7 @@ void print_summary(fitsfile *infits, 	/* input fits file   */
     char extver[10];
     char extnv[2*FLEN_VALUE+4];
     long npix;
+    LONGLONG nrows;
     int hdutype;
 
     /* get the error number and wrn number */ 
@@ -3158,12 +3166,13 @@ void print_summary(fitsfile *infits, 	/* input fits file   */
             strcat(extnv,extver);
         }
 
+        nrows = (hduptr->naxis >= 2) ? hduptr->naxes[1] : 0;
 #if (USE_LL_SUFFIX == 1)
         sprintf(comm," %s  (%d columns x %lld rows)", extnv, hduptr->ncols,
-           hduptr->naxes[1]);
+           nrows);
 #else
         sprintf(comm," %s  (%d columns x %ld rows)", extnv, hduptr->ncols,
-           hduptr->naxes[1]);
+           nrows);
 #endif
         wrtout(out,comm);
         if(hduptr->ncols) {
@@ -3346,7 +3355,8 @@ void close_hdu( FitsHdu *hduptr )
 	if(hduptr->ncols > 0)free(tunit);
 	if(hduptr->ncols > 0)free(tform);
     }
-    if(hduptr->naxis) free(hduptr->naxes);
+    free(hduptr->naxes);
+    hduptr->naxes = NULL;
     if(hduptr->ncols > 0)free(hduptr->datamax);
     if(hduptr->ncols > 0)free(hduptr->datamin);
     if(hduptr->ncols > 0)free(hduptr->tnull);

--- a/utilities/fvrf_head.c
+++ b/utilities/fvrf_head.c
@@ -2441,7 +2441,14 @@ void test_bin_ext(fitsfile *infits, 	/* input fits file   */
         p++;
 	if(!isdigit((int)*p))continue;
 	width = (int)strtol(p,NULL,10);
-	if(repeat%width != 0)  { 
+	if(width == 0)  {
+	    sprintf(errmes,
+	 "TFORM %s of column %d: the substring width must not be zero.",
+	    tform[i], i+1);
+            wrterr(out,errmes,1);
+            continue;
+        }
+	if(repeat%width != 0)  {
 	    sprintf(errmes,
 	 "TFORM %s of column %d: repeat %d is not the multiple of the width %d",
 	    tform[i], i+1, repeat, width);

--- a/utilities/fvrf_head.c
+++ b/utilities/fvrf_head.c
@@ -195,7 +195,7 @@ void init_hdu(fitsfile *infits, 	/* input fits file   */
     LONGLONG lv,lu=0L; 
     
 
-    FitsKey tmpkey;
+    FitsKey tmpkey = {"", UNKNOWN, "", 0, 0};
 
     hduptr->hdunum = hdunum;
     hduptr->hdutype = hdutype;
@@ -251,6 +251,7 @@ void init_hdu(fitsfile *infits, 	/* input fits file   */
     }
 
     /* Parse the XTENSION/SIMPLEX  keyword */ 
+    tmpkey.kindex = 1;
     fits_parse_card(out, 1, cards[0], tmpkey.kname, 
         &(tmpkey.ktype), tmpkey.kvalue,comm); 
     if( *(tmpkey.kvalue) == ' ') {
@@ -327,6 +328,7 @@ void init_hdu(fitsfile *infits, 	/* input fits file   */
 
     /* Parse the keywords NAXISn */ 
     for (j = 3; j < 3 + hduptr->naxis; j++){  
+        tmpkey.kindex = 1+j;
         fits_parse_card(out, 1+j,cards[j], tmpkey.kname, 
 	    &(tmpkey.ktype), tmpkey.kvalue,comm); 
         p = tmpkey.kname+5; 
@@ -416,6 +418,7 @@ void init_hdu(fitsfile *infits, 	/* input fits file   */
     hduptr->tkeys = i; 
 
     /* parse the END key */ 
+    tmpkey.kindex = m+1;
     fits_parse_card(out,m+1,cards[hduptr->nkeys-1],
          tmpkey.kname,&(tmpkey.ktype),tmpkey.kvalue,comm) ; 
     

--- a/utilities/fvrf_key.c
+++ b/utilities/fvrf_key.c
@@ -315,7 +315,7 @@ void get_cmp(char **pt,     		/* card string */
     char **pp;
     char *pr_beg;			/* end of real part */
     char *pr_end=0;			/* end of real part */
-    char *pi_beg;			/* beginning of the imaginay part */
+    char *pi_beg=0;			/* beginning of the imaginay part */
     char *pi_end=0;			/* end of real part */
     int  nchar;
     int set_comm = 0;
@@ -368,19 +368,24 @@ void get_cmp(char **pt,     		/* card string */
     while(isspace((int)*p)&& *p != '\0')  p++; 
     *pt = *pt + (p - card); 
 
-    /* analyse the real and imagine part */ 
+    /* analyse the real and imagine part */
+    /* Without a comma there is no real/imaginary split to analyse: pr_end
+       and pi_beg were never set, so the NO_COMMA error recorded above is
+       the only diagnostic this value can produce. */
+    if(!set_comm) return;
+
     *pr_end = '\0';
-    *pi_end = '\0'; 
-    while(isspace((int)*pr_beg) && *pr_beg != '\0')  pr_beg++; 
-    while(isspace((int)*pi_beg) && *pi_beg != '\0')  pi_beg++; 
+    *pi_end = '\0';
+    while(isspace((int)*pr_beg) && *pr_beg != '\0')  pr_beg++;
+    while(isspace((int)*pi_beg) && *pi_beg != '\0')  pi_beg++;
     temp[0] = '\0';
     pp = &pr_beg;
-    get_num(pp, temp, &rtype, &tr); 
-    if(tr)*stat |= BAD_REAL; 
+    get_num(pp, temp, &rtype, &tr);
+    if(tr)*stat |= BAD_REAL;
     temp[0] = '\0';
     pp = &pi_beg;
-    get_num(pp, temp, &itype, &ti); 
-    if(ti)*stat |= BAD_IMG; 
+    get_num(pp, temp, &itype, &ti);
+    if(ti)*stat |= BAD_IMG;
     if(rtype == FLT_KEY || itype == FLT_KEY) *ktype = CMF_KEY;
     return;
 }

--- a/utilities/fvrf_misc.c
+++ b/utilities/fvrf_misc.c
@@ -136,7 +136,10 @@ int wrtserr(FILE *out, char* mess, int *status, int severity)
 {
     char* errfmt = "             %.67s\n";
     int i;
-    char tmp[20][80];
+    /* One row per message read below, plus the trailing empty row the print
+       loop always emits.  Each row holds a whole CFITSIO message, which is
+       up to FLEN_ERRMSG bytes including its terminator. */
+    char tmp[21][FLEN_ERRMSG];
     int nstack = 0;
 
     if(severity < err_report) { 
@@ -154,6 +157,9 @@ int wrtserr(FILE *out, char* mess, int *status, int severity)
         if(!i && tmp[nstack][0]=='\0') break;
         nstack++;
     }
+    /* the print loop below runs to nstack inclusive: when the loop above
+       stopped on its own count, that last row has not been written yet */
+    tmp[nstack][0] = '\0';
 
     if(out !=NULL) {
         if ((out!=stdout) && (out!=stderr)) { 


### PR DESCRIPTION
**A5** from an audit of the fitsverify sources, which had it as INSPECTION with
reachability unproven ("I did not manage to build one that gets past CFITSIO's
own header validation into `test_bin_ext`"). I found the way in, so both halves
are now **CONFIRMED**: SIGSEGV for the `NAXIS == 0` case, and an ASAN-confirmed
heap-buffer-overflow READ for `NAXIS == 1`.

## Reachability

`hduptr->naxes` holds exactly `naxis` elements, and `test_bin_ext` does

```c
hduptr->heap = (hduptr->naxes[0]) * (hduptr->naxes[1]);
```

CFITSIO does enforce `NAXIS = 2` for anything it parses as a table (`ffgttb`
→ `fftkyn(fptr, 3, "NAXIS", "2")`), which is why the malformed-table route is a
dead end. The way in is `init_hdu`'s tile-compressed-image detection, which
compares **raw card text**:

```c
if (!strncmp(p,"BINTABLE",8) && hduptr->hdutype == IMAGE_HDU) {
  hduptr->hdutype = BINARY_TBL;
  hduptr->istilecompressed = 1;
}
```

while CFITSIO compares the whole value string (`strcmp(xtension, "BINTABLE")`).
An image extension whose XTENSION value merely *starts with* `BINTABLE` —
`'BINTABLEX'` will do — is read by CFITSIO as an image and then routed into the
binary-table checks by fitsverify, carrying an image's NAXIS:

```
XTENSION= 'BINTABLEX'
BITPIX  =                    8
NAXIS   =                    0        (or 1)
PCOUNT  =                    0
GCOUNT  =                    1
```

```
NAXIS=0: Segmentation fault (core dumped), exit 139
         (naxes still holds the *previous* HDU's freed pointer — close_hdu
          frees it only `if(hduptr->naxis)`, and the FitsHdu is a stack struct
          reused across the HDU loop, so this is a use-after-free)
NAXIS=1: ASAN heap-buffer-overflow READ at fvrf_head.c:2368
after:   both verify and report the header problems, exit 4 / 5
```

## The fix

- `init_hdu` sets `naxes = NULL` before the conditional allocation, so a stale
  pointer cannot survive into the next HDU;
- `close_hdu` frees on the pointer rather than on `naxis`, and clears it;
- `test_bin_ext` and `print_summary` index `naxes[1]` only when `NAXIS >= 2`.

I deliberately did **not** tighten the `strncmp(p,"BINTABLE",8)` prefix match
itself — that is fitsverify's own reading of the card and changing it would
change which HDUs get the binary-table checks at all. The bounds are the bug.

Genuine tile-compressed images are unaffected (they are binary tables with
`NAXIS = 2`), and output on well-formed files is unchanged — verified
byte-for-byte against `testprog.fit`.

## Test

`tests/test_fitsverify.c` covers both malformed shapes, failing if the binary
is killed by a signal (`signal 11` without the fix), and additionally builds a
real RICE-compressed image with the library and requires it to still be
verified as a binary table with no errors.

## Merge order

A stacked set of eight fitsverify fixes on top of a build-system base,
all targeting `develop`. Merge in this order:

0. #170 - Makefile.in reproducible from Makefile.am (build system, no code change)
1. #160 - get_cmp NULL dereference
2. #161 - TFORM zero substring width
3. #162 - bit column report overflow
4. #163 - uninitialised keyword index
5. #164 - test_agap column template
6. #165 - test_agap short read
7. #166 - wrtserr message array
8. #167 - naxes[] bounds  <- this PR

#170 is split out so that the `Makefile.in` regeneration is reviewable on
its own; the eight fixes share `tests/test_fitsverify.c`, which is why they
are stacked on each other rather than independent. Merged in this order
there are no conflicts. Until the ones before it are merged this PR's diff
also shows their commits; it shrinks to just its own change as they go in.

## Provenance

Found by an agent, fixed by an agent, reviewed by a human. The defect list came
out of automated analysis, the reproducer, the fix and the test were written by
an agent, and a human reviewed the change on the fork
(cruzzil/cfitsio-tmp#17) before it was sent here.
