### PR TITLE
Fix ffgttb discarding three of its keyword checks

### DIFF
--- a/getkey.c
+++ b/getkey.c
@@ -3385,12 +3385,12 @@ int ffgttb(fitsfile *fptr,      /* I - FITS file pointer*/
     if (ffgtknjj(fptr, 4, "NAXIS1", rowlen, status) == BAD_ORDER) /* 4th key */
         return(*status = NO_NAXES);  /* keyword not NAXIS1 */
     else if (*status == NOT_POS_INT)
-        return(*status == BAD_NAXES); /* bad NAXIS1 value */
+        return(*status = BAD_NAXES); /* bad NAXIS1 value */
 
     if (ffgtknjj(fptr, 5, "NAXIS2", nrows, status) == BAD_ORDER) /* 5th key */
         return(*status = NO_NAXES);  /* keyword not NAXIS2 */
     else if (*status == NOT_POS_INT)
-        return(*status == BAD_NAXES); /* bad NAXIS2 value */
+        return(*status = BAD_NAXES); /* bad NAXIS2 value */
 
     if (ffgtknjj(fptr, 6, "PCOUNT", pcount, status) == BAD_ORDER) /* 6th key */
         return(*status = NO_PCOUNT);  /* keyword not PCOUNT */
@@ -3405,7 +3405,7 @@ int ffgttb(fitsfile *fptr,      /* I - FITS file pointer*/
     if (ffgtkn(fptr, 8, "TFIELDS", tfields, status) == BAD_ORDER) /* 8th key*/
         return(*status = NO_TFIELDS);  /* keyword not TFIELDS */
     else if (*status == NOT_POS_INT || *tfields > 999)
-        return(*status == BAD_TFIELDS); /* bad TFIELDS value */
+        return(*status = BAD_TFIELDS); /* bad TFIELDS value */
 
 
     if (*status > 0)

--- a/tests/test_getkey.c
+++ b/tests/test_getkey.c
@@ -313,6 +313,167 @@ test_ffpknjj(void)
 	call_01(ffclos, f);
 }
 
+/*
+ * ffgttb validates the mandatory table keywords, so exercising it needs
+ * headers the library itself would never write.  Build them by hand.
+ */
+
+/* Write one 80 column card, blank padded. */
+static void
+put_card(FILE *fp, long *nbytes, const char *card)
+{
+	char buf[81];
+
+	snprintf(buf, sizeof(buf), "%-80.80s", card);
+	fwrite(buf, 1, 80, fp);
+	*nbytes += 80;
+}
+
+/* Pad with blanks out to the next 2880 byte block. */
+static void
+pad_block(FILE *fp, long *nbytes)
+{
+	while (*nbytes % 2880) {
+		fputc(' ', fp);
+		(*nbytes)++;
+	}
+}
+
+/*
+ * An empty primary array followed by a one column binary table.  The three
+ * cards ffgttb is being tested on are passed in whole.
+ */
+static void
+write_table_file(const char *path, const char *naxis1, const char *naxis2,
+		 const char *tfields)
+{
+	FILE *fp = fopen(path, "wb");
+	long n = 0;
+	int i;
+
+	fail_if(fp == NULL);
+
+	put_card(fp, &n, "SIMPLE  =                    T");
+	put_card(fp, &n, "BITPIX  =                    8");
+	put_card(fp, &n, "NAXIS   =                    0");
+	put_card(fp, &n, "EXTEND  =                    T");
+	put_card(fp, &n, "END");
+	pad_block(fp, &n);
+
+	put_card(fp, &n, "XTENSION= 'BINTABLE'");
+	put_card(fp, &n, "BITPIX  =                    8");
+	put_card(fp, &n, "NAXIS   =                    2");
+	put_card(fp, &n, naxis1);
+	put_card(fp, &n, naxis2);
+	put_card(fp, &n, "PCOUNT  =                    0");
+	put_card(fp, &n, "GCOUNT  =                    1");
+	put_card(fp, &n, tfields);
+	put_card(fp, &n, "TFORM1  = '10A     '");
+	put_card(fp, &n, "TTYPE1  = 'COL1    '");
+	put_card(fp, &n, "END");
+	pad_block(fp, &n);
+
+	for (i = 0; i < 10; i++) {
+		fputc('x', fp);
+		n++;
+	}
+	pad_block(fp, &n);
+
+	fail_if(fclose(fp) != 0);
+}
+
+/* Status left by moving to the table, or 0 if it was accepted. */
+static int
+move_to_table(void)
+{
+	fitsfile *f;
+	int status = 0;
+	int closestatus = 0;
+	int hdutype = 0;
+
+	call_03(ffopen, &f, test_path, READONLY);
+	ffmahd(f, 2, &hdutype, &status);
+	ffclos(f, &closestatus);
+	fail_if(closestatus != 0);
+	ffcmsg();
+	return status;
+}
+
+static void
+test_ffgttb_bad_keywords(void)
+{
+	/*
+	 * A value that is not a positive integer has to be reported as such.
+	 * These three checks used to compare where they meant to assign, so
+	 * ffgttb returned 0 with the status still set to NOT_POS_INT: the
+	 * caller carried on into ffbinit with uninitialised keyword values
+	 * and reported whatever error that ran into next.
+	 */
+	write_table_file(test_path, "NAXIS1  =                   -1",
+			 "NAXIS2  =                    1",
+			 "TFIELDS =                    1");
+	fail_if(move_to_table() != BAD_NAXES);
+
+	write_table_file(test_path, "NAXIS1  =                   10",
+			 "NAXIS2  =                   -1",
+			 "TFIELDS =                    1");
+	fail_if(move_to_table() != BAD_NAXES);
+
+	/* Not an integer at all. */
+	write_table_file(test_path, "NAXIS1  = 'abc'",
+			 "NAXIS2  =                    1",
+			 "TFIELDS =                    1");
+	fail_if(move_to_table() != BAD_NAXES);
+
+	write_table_file(test_path, "NAXIS1  =                   10",
+			 "NAXIS2  =                    1",
+			 "TFIELDS =                   -1");
+	fail_if(move_to_table() != BAD_TFIELDS);
+
+	/*
+	 * More than 999 fields cannot be written as valid FITS - TFORM1000
+	 * is a nine character keyword name - and the limit is checked for,
+	 * but the result of the check was being discarded.
+	 */
+	write_table_file(test_path, "NAXIS1  =                   10",
+			 "NAXIS2  =                    1",
+			 "TFIELDS =                 1000");
+	fail_if(move_to_table() != BAD_TFIELDS);
+}
+
+static void
+test_ffgttb_good_keywords(void)
+{
+	fitsfile *f;
+	int status = 0;
+	int hdutype = 0;
+	LONGLONG nrows = 0;
+	int ncols = 0;
+
+	write_table_file(test_path, "NAXIS1  =                   10",
+			 "NAXIS2  =                    1",
+			 "TFIELDS =                    1");
+
+	call_03(ffopen, &f, test_path, READONLY);
+	call_03(ffmahd, f, 2, &hdutype);
+	fail_if(hdutype != BINARY_TBL);
+	call_02(ffgnrwll, f, &nrows);
+	call_02(ffgncl, f, &ncols);
+	fail_if(nrows != 1);
+	fail_if(ncols != 1);
+	call_01(ffclos, f);
+
+	/*
+	 * Zero is a legal value for these keywords, so ffgttb has nothing to
+	 * say about this header; the complaint comes from the later check
+	 * that the column widths add up to NAXIS1.
+	 */
+	write_table_file(test_path, "NAXIS1  =                    0",
+			 "NAXIS2  =                    0",
+			 "TFIELDS =                    1");
+	fail_if(move_to_table() != BAD_ROW_WIDTH);
+}
+
 int
 main(void)
 {
@@ -334,6 +495,10 @@ main(void)
 
 	/* Keyword writing */
 	test_ffpknjj();
+
+	/* Mandatory table keywords */
+	test_ffgttb_good_keywords();
+	test_ffgttb_bad_keywords();
 
 	return 0;
 }


### PR DESCRIPTION
Found while investigating the `fitsverify` defects (it is what lets an ASCII
table with `NAXIS1 = 0` through, see #14) — but this one is in the library, not
the utility, so it gets its own branch.

## The bug

`getkey.c:ffgttb()` validates the mandatory table keywords. Three of its checks
compare where they meant to assign:

```c
else if (*status == NOT_POS_INT)
    return(*status == BAD_NAXES); /* bad NAXIS1 value */
```

That returns the value of a comparison — `0`, since `NOT_POS_INT` is not
`BAD_NAXES` — and leaves `*status` at `NOT_POS_INT`. Both callers test the
**return value**, not the status:

```c
if (ffgttb(fptr, &rowlen, &nrows, &pcount, &tfield, status) > 0)
   return(*status);
```

so `ffainit()` / `ffbinit()` carry straight on past the failed check — with
`*status` non-zero, and with `rowlen`, `nrows`, `pcount` and `tfield` still
**uninitialised**, because `ffgttb` returned before it could set them. Those
uninitialised values are then used: `ffainit` compares `pcount` against 0, and
both routines store `rowlen` and `tfield` into the `FITSfile` structure and
size the column table from `tfield`.

The HDU does still get rejected, but by whatever unrelated error the garbage
runs into next. A binary table with `NAXIS1 = -1`:

```
before: status 111  (ARRAY_TOO_BIG — from calloc()ing the column table with an
                     uninitialised field count)
after:  status 213  (BAD_NAXES)
```

Same for `NAXIS2 = -1` and for a non-integer value such as `NAXIS1 = 'abc'`.

The TFIELDS check discards more than just the status code:

```c
else if (*status == NOT_POS_INT || *tfields > 999)
    return(*status == BAD_TFIELDS);
```

With `*status == 0` and more than 999 fields this returns 0 **and leaves
`*status` 0**, so the 999 field limit is not enforced at all. In practice such
a file is malformed anyway (`TFORM1000` is a nine-character keyword name, which
FITS cannot express), so it was being rejected later with `NO_TFORM` (232)
rather than `BAD_TFIELDS` (216) — no file that used to load stops loading.

## The fix

Assign in all three places, matching every other check in the same function.
The lines are unchanged since CFITSIO V3.000 (2005).

## Tests

`tests/test_getkey.c` gains `ffgttb` coverage — the module's existing test, so
no build wiring changes and no conflicts with the fitsverify PRs. Hand-built
table headers with a negative, a non-integer and an over-large mandatory
keyword, each of which must now be reported as the malformed keyword it is,
plus a well-formed table and a zero-length one to pin down which check does the
complaining. Fails on `BAD_NAXES` without the fix.

`make check` is green, and the legacy regression still matches
(`testprog.lis` vs `testprog.out`, `testprog.fit` vs `testprog.std`).

## Provenance

Found by an agent, fixed by an agent, reviewed by a human. The defect list came
out of automated analysis, the reproducer, the fix and the test were written by
an agent, and a human reviewed the change on the fork
(cruzzil/cfitsio-tmp#18) before it was sent here.