### PR TITLE
Make the checked-in Makefile.in reproducible from Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -191,6 +191,7 @@ eval:		# Rebuild eval_* files from flex/bison source
 
 # Distribution: ==========================================================
 
+DISTCHECK_CONFIGURE_FLAGS = --enable-reentrant
 
 EXTRA_DIST = $(F77_WRAPPERS) ${GSIFTP_SRC} \
 	docs licenses \


### PR DESCRIPTION
Split out of the fitsverify fix stack at a reviewer's request: this is the
build-system change on its own, so the fixes that follow carry nothing but
their own `Makefile.in` entries.

## What this is

Running `automake` over this tree reproduces `Makefile.in` byte for byte, with
exactly one exception:

```
DISTCHECK_CONFIGURE_FLAGS = --enable-reentrant
```

That line is in the generated `Makefile.in` but has never been in
`Makefile.am`, so it can only have been added to the generated file by hand.
Any regeneration silently drops it — which takes `--enable-reentrant` out of
the configure run that `make distcheck` performs, so the reentrant build quietly
stops being covered by CI.

## The change

Move the line to `Makefile.am`, where automake emits it in the same place it
already occupies in `Makefile.in`.

**`Makefile.in` is unchanged by this PR, and that is the point**: regenerating
with automake 1.18.1 — the version that produced the current file, per its own
version stamp — is now a no-op, so any later change to `Makefile.am` can be
regenerated without silently losing anything.

## Verified

- `automake Makefile` on this branch leaves `Makefile.in` byte-identical
  (`cmp` clean against `develop`'s copy).
- `make -n distcheck` still passes `--enable-reentrant` to its configure run.
- Full `make distcheck` passes end to end.
- `make check`: 55 pass, 1 skip, 0 fail.

## Merge order

Base of a stacked set of eight fitsverify fixes (#160 - #167), which are
branched off this one and should be merged after it, in number order.


