### PR TITLE
`editcol.c`: two silent-data-loss defects in `fits_parse_range` and `fits_modify_vector_len`

### DIFF
--- a/editcol.c
+++ b/editcol.c
@@ -1464,6 +1464,8 @@ int ffmvec(fitsfile *fptr,  /* I - FITS file pointer                        */
       colptr += (colnum - 1);
 
       firstcol = colptr->tbcol + (repeat * width);  /* insert position */
+      if (datacode == TBIT)  /* repeat counts bits, not bytes */
+         firstcol = colptr->tbcol + ((repeat + 7) / 8);
 
       /* insert delbyte bytes in every row, at byte position firstcol */
       ffcins(fptr, naxis1, naxis2, delbyte, firstcol, status);
@@ -1475,6 +1477,8 @@ int ffmvec(fitsfile *fptr,  /* I - FITS file pointer                        */
       freespace = ((size + 2879) / 2880) * 2880 - size - ((LONGLONG)delbyte * naxis2);
       nblock = (long) (freespace / 2880);   /* number of empty blocks to delete */
       firstcol = colptr->tbcol + (newveclen * width);  /* delete position */
+      if (datacode == TBIT)  /* newveclen counts bits, not bytes */
+         firstcol = colptr->tbcol + ((newveclen + 7) / 8);
 
       /* delete elements from the vector */
       ffcdel(fptr, naxis1, naxis2, -delbyte, firstcol, status);

--- a/editcol.c
+++ b/editcol.c
@@ -789,6 +789,7 @@ int ffrwrg(
 */
     char *next;
     long minval, maxval;
+    int anyrange;    /* did the parse loop consume any range token? */
 
     if (*status > 0)
         return(*status);
@@ -801,10 +802,13 @@ int ffrwrg(
 
     next = rowlist;
     *numranges = 0;
+    anyrange = 0;
 
     while (*next == ' ')next++;   /* skip spaces */
    
     while (*next != '\0') {
+
+      anyrange = 1;
 
       /* find min value of next range; *next must be '-' or a digit */
       if (*next == '-') {
@@ -891,7 +895,7 @@ int ffrwrg(
       }
     }
 
-    if (*numranges == 0) {  /* a null string was entered */
+    if (*numranges == 0 && !anyrange) {  /* a null string was entered */
          minrow[0] = 1;
          maxrow[0] = (long) maxrows;
          *numranges = 1;
@@ -928,6 +932,7 @@ int ffrwrgll(
     char *next;
     LONGLONG minval, maxval;
     double dvalue;
+    int anyrange;    /* did the parse loop consume any range token? */
 
     if (*status > 0)
         return(*status);
@@ -940,10 +945,13 @@ int ffrwrgll(
 
     next = rowlist;
     *numranges = 0;
+    anyrange = 0;
 
     while (*next == ' ')next++;   /* skip spaces */
    
     while (*next != '\0') {
+
+      anyrange = 1;
 
       /* find min value of next range; *next must be '-' or a digit */
       if (*next == '-') {
@@ -1042,7 +1050,7 @@ int ffrwrgll(
       }
     }
 
-    if (*numranges == 0) {  /* a null string was entered */
+    if (*numranges == 0 && !anyrange) {  /* a null string was entered */
          minrow[0] = 1;
          maxrow[0] = maxrows;
          *numranges = 1;


### PR DESCRIPTION

The PR below details two CFITSIO bugs found by Demitri Muna while building an independent test suite for CFITSIO. I checked them against currently reported bugs, published Doyensec advisories (Q2-2025, Q4-2025, Q1-2026) and CVE databases and found no prior report (see "Prior art" below for what was checked). I have reviewed the text below but it was written by AI.

Two independent defects in `editcol.c`, one commit each. They are unrelated in mechanism and share only the file — their hunks are about 500 lines apart and would merge cleanly as separate PRs, so this is grouping for your convenience rather than necessity. Say the word and I will split them.

Both are silent: the library returns `status` 0 and a file that `fitsverify` accepts.

## 1. `ffrwrg`/`ffrwrgll` — an all-out-of-range row list is treated as an empty one

**Class:** silent data loss — destructive; the entire table is deleted and `status` is 0
**Impact:** `fits_delete_rowrange(f, "200-300", &status)` on a 50-row table removes all 50 rows
**Reachability:** ordinary use — a documented, syntactically valid input
**Fix:** track whether the parse loop consumed any range token and gate the fallback on that instead of on the count alone; `ffdrrg`'s existing no-op guard then works unchanged

`ffrwrg` skips any range lying entirely beyond `maxrows` (`editcol.c:877`), and then applies a fallback intended for empty input (`:894`). `*numranges == 0` is reachable two ways — a genuinely empty `rowlist`, and a non-empty one whose ranges were all discarded — and the function cannot distinguish them, so `"200-300"` against a 50-row table is handled exactly like `""`: select everything.

`fits_delete_rowrange` is where that turns destructive. Its own no-op guard at `:470` is correct, but it never sees the empty result: the fallback has already replaced it with one range spanning the whole table.

The fix records whether the parse loop consumed any range token, and gates the fallback on that rather than on the count alone. `ffdrrg` needs no change — once `ffrwrg` stops mis-reporting, its existing guard does the right thing. The same change is applied to the `LONGLONG` twin `ffrwrgll`, which carries the identical pattern.

There is a tidier shape if you prefer it: hoist the empty-input test above the parse loop — `while (*next == ' ') next++; if (*next == '\0') { minrow[0] = 1; maxrow[0] = maxrows; *numranges = 1; return *status; }` — and delete the trailing block entirely. That needs no new local in either function and makes the comment "a null string was entered" literally true. The flag is the smaller diff, which is why it is what this PR carries; the hoisted version is behaviourally identical, whitespace-only input included.

The realistic trigger is a pipeline that caches a row-range string — "drop yesterday's calibration rows" — and re-runs it against a table that has since shrunk below that range. The result is an empty table and a zero status.

Note this is an API-visible behaviour change for `fits_parse_range`: an all-out-of-range list now returns `numranges = 0` instead of one full-table range. That is what the documentation describes ("any rows or ranges larger than this will be ignored"), and the manual reserves the literal `"-"`, not the empty string, for "all rows" — but it is a change, so it is your call whether it can go into a patch release.

## 2. `ffmvec` — the TBIT insert/delete position is computed in bits, not bytes

**Class:** silent data corruption — adjacent columns are overwritten and `status` is 0
**Impact:** resizing an `X` column corrupts the columns beside it; the file still passes `fitsverify`
**Reachability:** ordinary use — any byte-footprint-changing resize of an `X` column
**Fix:** convert both position sites to `tbcol + ceil(n/8)`, the same bits→bytes conversion `a7bcb9c` already applied to the delbyte line

`ffmvec` special-cases `TBIT` when computing **how many** bytes to insert or remove (`:1416`), but not **where**:

```c
/* editcol.c:1458 (grow)   */  firstcol = colptr->tbcol + (repeat * width);
/* editcol.c:1469 (shrink) */  firstcol = colptr->tbcol + (newveclen * width);
```

For a `TBIT` column `trepeat` counts bits and `twidth` is 1, so `n * width` is a bit count used as a byte offset. The correct position is `tbcol + ceil(n/8)`. Growing an `8X` column — one byte on disk — inserts at `tbcol + 8`, seven bytes past the column's end.

This is the same conversion `a7bcb9c` (v3.07, Nov 2007) corrected on the `delbyte` line, changing `(n + 1) / 8` to `(n + 7) / 8`. That fix did not carry the conversion to the two position sites; this change finishes it, in the same shape as the existing special case.

Three failure modes, all requiring `delbyte != 0` and `n >= 2`. On wide rows (`tbcol + n` within the row) it is silent: the insert lands at the wrong offset and the `n - ceil(n/8)`-byte window between correct and computed position is corrupted — 7 bytes for `n = 8`. On narrow rows with two or more rows it is loud (`307 BAD_ROW_NUM`, from the row-shifting end-of-table check), but on *shrink* the forward loop can already have destroyed leading rows before the failing read. On narrow rows with exactly one row it is silent again: both shift loops are no-ops, no bytes move, yet `TFORMn` and `NAXIS1` are updated and status 0 returned, leaving every following column misaligned.

## Reproductions

Attached, one per defect, both standalone C programs that exit 1 when the defect is present and 0 when it is fixed. They assert values, not just `status`: the `ffmvec` one covers eight scenarios — the seven defect cases plus a same-footprint control that must keep working — and on every status-0 result checks the full public contract (`TFORMn` repeat, `NAXIS1`, bit round-trip, trailing-column integrity), so a partial fix fails rather than reading as fixed.

I have not added anything to `tests/`. These reproductions are the verification artifact.

## Verification

Against upstream `develop` `d6d2765`, macOS, AppleClang, built with `./configure && make`:

| | `bug_034` repro | `bug_009` repro | `make check` |
|---|---|---|---|
| `d6d2765` unpatched | exit 1 — 50-row table emptied, status 0 | exit 1 — all 7 defect scenarios reproduce | 55 total, 54 pass, 1 skip, 0 fail |
| with both commits | exit 0 — 50 rows preserved | exit 0 — all 8 scenarios clean | 55 total, 54 pass, 1 skip, 0 fail |

The `make check` columns are the point of that table: the baseline and the patched tree give identical results, so no existing test depended on either behaviour. In particular `test_ffrwrgll` in `tests/test_editcol.c` still passes — its two cases are in range, so the changed fallback is not on their path.

Non-regression cases checked by hand for the row-range change, since it alters a public function's output: `fits_delete_rowrange("5-10")` on 50 rows still deletes 6 rows, and `fits_delete_rowrange("")` still deletes all 50 — the empty-string semantics the `:894` fallback exists to provide are preserved. Only the all-out-of-range case moves.

## Prior art

Evidence that these have been previously reported was searched: this repository's issues and pull requests, open and closed, searched by function name and by symptom; the commit history for a fix (`git log -S 'if (*numranges == 0)' -- editcol.c` returns `b2dd182`, the April 2002 commit that *introduced* the fallback three days before the v2.410 release, and `d80e242` from March 2005, which only moves surrounding code; `git log -S 'firstcol = colptr->tbcol' -- editcol.c` returns only `07892fc`, from 2000); the published ChangeLog, whose four `ffmvec` entries — the 2007 `'X'` fix above, a v3.43 `colptr`-reset fix credited to Willem van Straten, a v3.47 EOF-error fix and a v2.202 shrink-corruption fix — none touch the position arithmetic; the three Doyensec CFITSIO advisories (Q2-2025, Q4-2025, Q1-2026); CVE databases; and the commit log of rsfitsio, an independent Rust translation of this library (searched for `ffrwrg`, `ffmvec`, `editcol`, `parse_range` and `modify_vector_len`; its one `parse_range` hit is expression-evaluator work, unrelated). Nothing found in those sources, which is not the same as "no report exists."
