### PR TITLE
`getcoluj.c`: `fffi2u8` uses signed bounds for an unsigned output, so a negative TSHORT reads back as ~1.8e19

### DIFF
--- a/getcoluj.c
+++ b/getcoluj.c
@@ -3012,18 +3012,18 @@ int fffi2u8(short *input,         /* I - array of values to be converted     */
             {
                 dvalue = input[ii] * scale + zero;
 
-                if (dvalue < DLONGLONG_MIN)
+                if (dvalue < 0)
                 {
                     *status = OVERFLOW_ERR;
-                    output[ii] = LONGLONG_MIN;
+                    output[ii] = 0;
                 }
-                else if (dvalue > DLONGLONG_MAX)
+                else if (dvalue >= 18446744073709551616.)  /* 2^64 */
                 {
                     *status = OVERFLOW_ERR;
-                    output[ii] = LONGLONG_MAX;
+                    output[ii] = UINT64_MAX;
                 }
                 else
-                    output[ii] = (LONGLONG) dvalue;
+                    output[ii] = (ULONGLONG) dvalue;
             }
         }
     }
@@ -3041,8 +3041,15 @@ int fffi2u8(short *input,         /* I - array of values to be converted     */
                     else
                         nullarray[ii] = 1;
                 }
+	        else if (input[ii] < 0)
+		{
+                   *status = OVERFLOW_ERR;
+                    output[ii] = 0;
+                }
                 else
-                    output[ii] = (LONGLONG) input[ii];
+		{
+                    output[ii] = (ULONGLONG) input[ii];
+		}
             }
         }
         else                  /* must scale the data */
@@ -3061,18 +3068,18 @@ int fffi2u8(short *input,         /* I - array of values to be converted     */
                 {
                     dvalue = input[ii] * scale + zero;
 
-                    if (dvalue < DLONGLONG_MIN)
+                    if (dvalue < 0)
                     {
                         *status = OVERFLOW_ERR;
-                        output[ii] = LONGLONG_MIN;
+                        output[ii] = 0;
                     }
-                    else if (dvalue > DLONGLONG_MAX)
+                    else if (dvalue >= 18446744073709551616.)  /* 2^64 */
                     {
                         *status = OVERFLOW_ERR;
-                        output[ii] = LONGLONG_MAX;
+                        output[ii] = UINT64_MAX;
                     }
                     else
-                        output[ii] = (LONGLONG) dvalue;
+                        output[ii] = (ULONGLONG) dvalue;
                 }
             }
         }


### PR DESCRIPTION

The PR below details a CFITSIO bug found by Demitri Muna while building an independent test suite for CFITSIO. I checked it against currently reported bugs, published Doyensec advisories (Q2-2025, Q4-2025, Q1-2026) and CVE databases and found no prior report (see "Prior art" below for what was checked). I have reviewed the text below but it was written by AI.

**Class:** silent data loss — a negative value reads back as ~1.8e19 and `status` is 0
**Impact:** any reader pulling a `TSHORT` column into a `TULONGLONG` buffer corrupts negatives
**Reachability:** ordinary use — a plain `fits_read_col(..., TULONGLONG, ...)` call
**Fix:** mechanical; the six other `*u8` converters in this file already have this shape, with two deliberate differences noted below

`fffi2u8()` converts `TSHORT` column data into a `TULONGLONG` caller buffer. It looks like it was copied from the signed `fffi2i8` and never adapted to the unsigned output type, and three of its four branches are wrong:

| Branch | State |
|---|---|
| `nullcheck == 0`, no scaling | **correct** — guards `< 0`, clamps to 0 with `OVERFLOW_ERR` |
| `nullcheck == 0`, scaled | clamps to `LONGLONG_MIN`/`LONGLONG_MAX` instead of `0`/`UINT64_MAX` |
| `nullcheck != 0`, no scaling | **no `< 0` guard at all** — bare cast into the unsigned output |
| `nullcheck != 0`, scaled | same wrong signed bounds |

Every other `*u8` converter in this file — `fffi1u8`, `fffi4u8`, `fffi8u8`, `fffr4u8`, `fffr8u8` and `fffstru8` — clamps a semantically negative result to `0` and sets `OVERFLOW_ERR`. `fffi2u8` is the only one that does not, so this patch is that established form rather than a new policy — with the single deliberate exception described two paragraphs down.

The third row is the one that bites in ordinary use. After the `TNULL` comparison, a non-null negative short goes straight through `output[ii] = (LONGLONG) input[ii]` into a `ULONGLONG` slot: `-5` becomes `18446744073709551611`, `status` stays 0 and `anynull` stays 0, so nothing signals the loss. It needs only a column with a valid in-range `TNULL` and a caller passing a nonzero `nulval` — which is what engages null checking.

The patch also widens the two final casts in the scaled branches from `(LONGLONG)` to `(ULONGLONG)`. That is not cosmetic: once the upper bound admits values above `LONGLONG_MAX`, they reach the cast, and converting such a `double` to a signed type is undefined. The old signed bound was what kept that cast safe.

**The upper test is `dvalue >= 18446744073709551616.` rather than the siblings' `dvalue > DULONGLONG_MAX`, and both differences are deliberate.**

It has to be `>=`. `DULONGLONG_MAX` is 2^64 − 1, which an IEEE-754 binary64 `double` cannot hold. **Measured here** (macOS, AppleClang, binary64): the literal rounds up to exactly 2^64, so `>` lets `dvalue == 2^64` through to the cast — one past what a `ULONGLONG` holds. I wrote `>` first, to match the siblings exactly, and measured that it loses an error the *unpatched* code does report: at `dvalue == 2^64` the old signed bound returns `OVERFLOW_ERR`, and `>` returned `UINT64_MAX` at `status` 0.

And the bound is written out rather than taken from the macro because `>=` against a value whose rounding is implementation-defined is worse than `>` was. Where the macro rounds *down*, `>=` would clamp the largest representable value below 2^64 — 2^64 − 2048 on binary64, some other predecessor elsewhere — which a `ULONGLONG` holds exactly. And on a binary format with 64 or more mantissa bits the macro needs no rounding at all, so `>=` against it would reject `UINT64_MAX` itself, a perfectly valid value. Writing 2^64 out avoids the whole question: it is a power of two, exact in any binary format, and the comparison means precisely "out of range" regardless of mantissa width or rounding mode. On binary64 it compiles to the same comparison the macro would have produced, so nothing local changes; the gain is that the guard no longer depends on the format.

On binary64, `DLONGLONG_MAX` rounds up the same way at 2^63, so the signed converters share this edge, and the `*u8` siblings still use `> DULONGLONG_MAX`. I have not touched them here. Separately, `DLONGLONG_MAX`'s own literal appears to carry a mantissa typo, unrelated to the rounding above and out of scope for this patch.

## Reproduction

Attached: a standalone C program that exits 1 when the defect is present, 0 when it is fixed, and 3 when the library does neither. It exercises **all three** defective branches — a plain negative short for the unscaled one, and a `TSCAL`/`TZERO` column whose raw 0 scales to −1000 and raw 2000 to +1000 for the two scaled ones — plus the upper clamp, via a second scaled column where `TZERO = 2^64` puts one row exactly on the bound and the other at 2^64 − 2048, the largest `double` below it. It carries a `1J` control column that goes through `fffi4u8`'s null-checking unscaled branch, which already has the `< 0` guard — a different branch from the one noted below as having its own problem, so the control is sound. The divergence between the two columns is therefore the defect rather than a property of the fixture.

Observed on `develop` `d6d2765`, unpatched:

```
SHORT col (fffi2u8): row1(-5)=18446744073709551611  row2(100)=100  status=0 anynull=0
INT   col (fffi4u8): row1(-5)=0  row2(100)=100  status=412 anynull=0
SCALED nullcheck==0: dv(-1000)=18446744073709550616  dv(+1000)=1000  status=0 anynull=0
SCALED nullcheck!=0: dv(-1000)=18446744073709550616  dv(+1000)=1000  status=0 anynull=0
UPPER  nullcheck==0: dv(2^64)=9223372036854775807  dv(2^64-2048)=9223372036854775807  status=412 anynull=0
UPPER  nullcheck!=0: dv(2^64)=9223372036854775807  dv(2^64-2048)=9223372036854775807  status=412 anynull=0
```

The last two lines are the upper clamp being loud but wrong: both rows come back as `LONGLONG_MAX`, including the one at 2^64 − 2048 that a `ULONGLONG` holds exactly.

With this patch, every negative result reads `0` at `status=412` (`NUM_OVERFLOW`), `+1000` and `100` pass through unchanged, `dvalue == 2^64` clamps to `UINT64_MAX`, and 2^64 − 2048 comes back exactly — what the control column already returns.

Two properties of that program worth stating, because they are what make it usable as a check on the patch rather than a demonstration. Each verdict asserts the **full vector** — both rows, the status and `anynull` — so a "fix" that clamped the non-negative value too would fail rather than pass. And the four section verdicts are **combined**, so a partial fix reports 3 rather than 0 — verified against two deliberately incomplete builds, one with only the unscaled guard applied and one with the `>=` reverted to `>`; both exit 3 and name the section that disagrees.

One fixture detail that is easy to get wrong: `TZERO4` is written as a literal card rather than through `fits_update_key(TDOUBLE, ...)`. The keyword writer formats a `double` to about 15 significant digits and 2^64 needs 20, so the round-trip returns 18446744073709600768 — past the bound, which quietly turns the on-bound case into an ordinary over-range one and makes that section test nothing.

I have not added anything to `tests/`. The reproduction is the verification artifact.

## Verification

Against upstream `develop` `d6d2765`, macOS, AppleClang, built with `./configure && make`:

| | reproduction | `make check` |
|---|---|---|
| `d6d2765` unpatched | exit 1 — all four sections show the defect | 55 total, 54 pass, 1 skip, 0 fail |
| unscaled guard only | exit 3 — names the two scaled branches still defective | — |
| this commit with `>=` reverted to `>` | exit 3 — names the upper clamp | — |
| with this commit | exit 0 — all four sections correct | 55 total, 54 pass, 1 skip, 0 fail |

Baseline and patched `make check` are identical, so no existing test depended on the old behaviour.

There is a possible related issue in the sibling converter `fffi4u8` — the same bound/cast mismatch, in its `nullcheck == 0` scaled branch. I have not verified it to the same standard as the fix above, so it is not part of this patch.

## Prior art

Evidence that this has been previously reported was searched: this repository's issues and pull requests, open and closed, searched for `fffi2u8`, `TULONGLONG` and by symptom; the commit history for a fix (`git log -S 'fffi2u8' -- getcoluj.c` returns only `7d9500b`, the 2018 commit that introduced the whole `*u8` family); the published ChangeLog; the three Doyensec CFITSIO advisories (Q2-2025, Q4-2025, Q1-2026); CVE databases; and the commit log of rsfitsio, an independent Rust translation of this library (searched for `fffi2u8` and `getcoluj`; no match). Nothing found in those sources, which is not the same as "no report exists."

Worth noting that `7d9500b` added the whole family in one commit, so the siblings that guard correctly and this one that does not were written together; it reads like a copy-paste from the signed variant rather than a later regression.
