### PR TITLE
Fix PLIO compressed tile buffer overflow

### DIFF
--- a/fitsio2.h
+++ b/fitsio2.h
@@ -1149,7 +1149,7 @@ int fits_rdecomp_short (unsigned char *c, int clen, unsigned short array[], int 
              int nblock);
 int fits_rdecomp_byte (unsigned char *c, int clen, unsigned char array[], int nx,
              int nblock);
-int pl_p2li (int *pxsrc, int xs, short *lldst, int npix);
+int pl_p2li (int *pxsrc, int xs, short *lldst, size_t dstlen, int npix);
 int pl_l2pi (short *ll_src, size_t srclen, int xs, int *px_dst, int npix);
 int fits_init_randoms(void);
 int fits_unset_compression_param( fitsfile *fptr, int *status);

--- a/imcompress.c
+++ b/imcompress.c
@@ -1476,6 +1476,15 @@ int imcomp_calc_max_elem (int comptype, int nx, int zbitpix, int blocksize)
         else
             return( (int) (nx * 4.4 + 26));   /* will be compressing 32-bit int array */
     }
+    else if (comptype == PLIO_1)
+    {
+        /* pl_p2li writes a 7 short header, followed by at most 3 shorts per
+	   pixel (2 to encode a pixel value that differs from the previous one
+	   by more than 4095, plus 1 for the run length).  Note that this is
+	   larger than the uncompressed 32-bit array for small tiles. */
+
+        return((int) ((3 * (size_t) nx + 7) * sizeof(short)));
+    }
     else
         return(nx * sizeof(int));
 }
@@ -1967,7 +1976,7 @@ int imcomp_compress_tile (fitsfile *outfptr,
                 }
               }
 
-  	      nelem = pl_p2li (idata, 1, cbuf, tilelen);
+  	      nelem = pl_p2li (idata, 1, cbuf, clen / sizeof(short), tilelen);
 
 	      if (nelem < 0)  /* data compression error condition */
               {

--- a/pliocomp.c
+++ b/pliocomp.c
@@ -5,13 +5,14 @@
    performing conversion between pixel arrays and line lists.  The
    compression technique is used in IRAF.
 */
-int pl_p2li (int *pxsrc, int xs, short *lldst, int npix);
+int pl_p2li (int *pxsrc, int xs, short *lldst, size_t dstlen, int npix);
 int pl_l2pi (short *ll_src, size_t srclen, int xs, int *px_dst, int npix);
 
 
 /*
  * PL_P2L -- Convert a pixel array to a line list.  The length of the list is
- * returned as the function value.
+ * returned as the function value, or -1 if the list does not fit in the
+ * dstlen shorts of the output buffer.
  *
  * Translated from the SPP version using xc -f, f2c.  8Sep99 DCT.
  */
@@ -23,10 +24,11 @@ int pl_l2pi (short *ll_src, size_t srclen, int xs, int *px_dst, int npix);
 #define max(a,b)        (((a)>(b))?(a):(b))
 #endif
 
-int pl_p2li (int *pxsrc, int xs, short *lldst, int npix)
+int pl_p2li (int *pxsrc, int xs, short *lldst, size_t dstlen, int npix)
 /* int *pxsrc;                      input pixel array */
 /* int xs;                          starting index in pxsrc (?) */
 /* short *lldst;                    encoded line list */
+/* size_t dstlen;                   number of shorts in lldst */
 /* int npix;                        number of pixels to convert */
 {
     /* System generated locals */
@@ -46,6 +48,9 @@ int pl_p2li (int *pxsrc, int xs, short *lldst, int npix)
     ret_val = 0;
     goto L100;
 L110:
+    if (dstlen < 7) {   /* no room for the line list header */
+        return -1;
+    }
     lldst[3] = -100;
     lldst[2] = 7;
     lldst[1] = 0;
@@ -101,12 +106,18 @@ L131:
         if (! (abs(dv) > 4095)) {
             goto L190;
         }
+        if ((size_t) op + 1 > dstlen) {
+            return -1;
+        }
         lldst[op] = (short) ((pv & 4095) + 4096);
         ++op;
         lldst[op] = (short) (pv / 4096);
         ++op;
         goto L191;
 L190:
+        if ((size_t) op > dstlen) {
+            return -1;
+        }
         if (! (dv < 0)) {
             goto L200;
         }
@@ -133,6 +144,9 @@ L230:
         if (! (nz > 0)) {
             goto L232;
         }
+        if ((size_t) op > dstlen) {
+            return -1;
+        }
         lldst[op] = (short) min(4095,nz);
         ++op;
 /* L231: */
@@ -149,6 +163,9 @@ L220:
 L250:
         if (! (np > 0)) {
             goto L252;
+        }
+        if ((size_t) op > dstlen) {
+            return -1;
         }
         lldst[op] = (short) (min(4095,np) + 16384);
         ++op;

--- a/tests/test_imcompress.c
+++ b/tests/test_imcompress.c
@@ -373,6 +373,92 @@ test_plio_compress(void)
 }
 
 /*
+ * PLIO round trip of one small image.  The compressed tile buffer used to be
+ * sized at 4 bytes per pixel, which is smaller than the 7 short header that
+ * pl_p2li() always writes, so compressing an image with short rows overran
+ * the heap - see heasarc/cfitsio issue #136.
+ */
+static void
+plio_roundtrip(long nx, long ny)
+{
+	fitsfile *infptr, *outfptr;
+	int status = 0;
+	long naxes[2];
+	long npix = nx * ny;
+	int *original, *decompressed;
+	long i;
+
+	naxes[0] = nx;
+	naxes[1] = ny;
+
+	original = malloc(npix * sizeof *original);
+	decompressed = malloc(npix * sizeof *decompressed);
+	fail_if(original == NULL || decompressed == NULL);
+
+	/*
+	 * Worst case for PLIO: every pixel differs from its neighbour by more
+	 * than 4095, so each one needs 3 shorts in the line list.
+	 */
+	for (i = 0; i < npix; i += 1) {
+		original[i] = (i % 2) ? 5000 : 1;
+	}
+
+	fits_create_file(&infptr, "!" test_path, &status);
+	fail_if(status != 0);
+	fits_create_img(infptr, LONG_IMG, 2, naxes, &status);
+	fail_if(status != 0);
+	fits_write_img(infptr, TINT, 1, npix, original, &status);
+	fail_if(status != 0);
+	fits_close_file(infptr, &status);
+	fail_if(status != 0);
+
+	fits_open_file(&infptr, test_path, READONLY, &status);
+	fail_if(status != 0);
+	fits_create_file(&outfptr, "!" test_path2, &status);
+	fail_if(status != 0);
+	fits_set_compression_type(outfptr, PLIO_1, &status);
+	fail_if(status != 0);
+	fits_img_compress(infptr, outfptr, &status);
+	fail_if(status != 0);
+	fits_close_file(infptr, &status);
+	fits_close_file(outfptr, &status);
+	fail_if(status != 0);
+
+	fits_open_file(&outfptr, test_path2, READONLY, &status);
+	fail_if(status != 0);
+	fits_movabs_hdu(outfptr, 2, NULL, &status);
+	fail_if(status != 0);
+	fits_read_img(outfptr, TINT, 1, npix, NULL, decompressed, NULL,
+		&status);
+	fail_if(status != 0);
+
+	for (i = 0; i < npix; i += 1) {
+		fail_if(decompressed[i] != original[i]);
+	}
+
+	fits_close_file(outfptr, &status);
+	fail_if(status != 0);
+
+	free(original);
+	free(decompressed);
+}
+
+/*
+ * Test PLIO compression of images whose rows are too short for the old
+ * compressed tile buffer size (issue #136)
+ */
+static void
+test_plio_small_images(void)
+{
+	plio_roundtrip(1, 1);
+	plio_roundtrip(2, 2);
+	plio_roundtrip(3, 3);
+	plio_roundtrip(5, 4);
+	plio_roundtrip(9, 3);
+	plio_roundtrip(33, 3);
+}
+
+/*
  * Test HCOMPRESS compression
  */
 static void
@@ -567,6 +653,7 @@ main(void)
 	test_rice_compress_short();
 	test_gzip_compress();
 	test_plio_compress();
+	test_plio_small_images();
 	test_hcompress_compress();
 	test_is_compressed_uncompressed();
 	test_compress_byte_image();

--- a/tests/test_pliocomp.c
+++ b/tests/test_pliocomp.c
@@ -5,10 +5,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "fitsio.h"
 #include "test_macros.h"
 
-int pl_p2li(int *, int, short *, int);
+int pl_p2li(int *, int, short *, size_t, int);
 int pl_l2pi(short *, size_t, int, int *, int);
+int imcomp_calc_max_elem(int, int, int, int);
 
 
 static void
@@ -17,7 +19,7 @@ test_array(int *in, size_t siz)
 	short linelist[100];
 	int output[16];
 
-	fail_if(pl_p2li(in, 1, linelist, siz) <= 0);
+	fail_if(pl_p2li(in, 1, linelist, 100, siz) <= 0);
 	fail_if(pl_l2pi(linelist, 100, 1, output, siz) != siz);
 
 	for (size_t i = 0; i < siz; i += 1) {
@@ -32,7 +34,7 @@ test_empty_input(void)
 	int pixels[1] = { 0 };
 	short linelist[100];
 
-	fail_if(pl_p2li(pixels, 1, linelist, 0));
+	fail_if(pl_p2li(pixels, 1, linelist, 100, 0));
 }
 
 static void
@@ -68,7 +70,7 @@ test_negative_clamp(void)
 	short linelist[100];
 	int output[3];
 
-	fail_if(pl_p2li(pixels, 1, linelist, 3) <= 0);
+	fail_if(pl_p2li(pixels, 1, linelist, 100, 3) <= 0);
 	fail_if(pl_l2pi(linelist, 100, 1, output, 3) != 3);
 
 	fail_if(output[0] != 0);
@@ -83,7 +85,7 @@ test_partial_decode(void)
 	short linelist[100];
 	int output[5];
 
-	fail_if(pl_p2li(pixels, 1, linelist, 10) <= 0);
+	fail_if(pl_p2li(pixels, 1, linelist, 100, 10) <= 0);
 	fail_if(pl_l2pi(linelist, 100, 1, output, 5) != 5);
 
 	for (int i = 0; i < 5; i += 1) {
@@ -108,7 +110,7 @@ test_decode_offset(void)
 	short linelist[100];
 	int output[5];
 
-	fail_if(pl_p2li(pixels, 1, linelist, 10) <= 0);
+	fail_if(pl_p2li(pixels, 1, linelist, 100, 10) <= 0);
 	fail_if(pl_l2pi(linelist, 100, 5, output, 5) != 5);
 }
 
@@ -119,7 +121,7 @@ test_decode_more_than_encoded(void)
 	short linelist[100];
 	int output[10];
 
-	fail_if(pl_p2li(pixels, 1, linelist, 5) <= 0);
+	fail_if(pl_p2li(pixels, 1, linelist, 100, 5) <= 0);
 	fail_if(pl_l2pi(linelist, 100, 1, output, 10) != 10);
 
 	for (int i = 0; i < 5; i += 1) {
@@ -171,6 +173,84 @@ test_opcode3_negative_delta(void)
 	fail_if(output[2] != 0);
 }
 
+/*
+ * Fill an array with the pattern that makes pl_p2li() emit the most shorts:
+ * every pixel differs from the previous one by more than 4095, so none of
+ * them can be encoded as a delta or merged into a run.
+ */
+static void
+worst_case_data(int *pixels, int npix)
+{
+	for (int i = 0; i < npix; i += 1) {
+		pixels[i] = (i % 2) ? 5000 : 1;
+	}
+}
+
+/*
+ * The line list must fit in the buffer that imcomp_calc_max_elem() asks
+ * imcompress.c to allocate, for any input.  It did not: the buffer was sized
+ * at 4 bytes per pixel with no allowance for the 7 short header, so small
+ * tiles overran the heap (heasarc/cfitsio issue #136).
+ */
+static void
+test_fits_in_calculated_buffer(void)
+{
+	int pixels[300];
+	short *linelist;
+	size_t capacity;
+	int maxelem, npix, ret;
+
+	for (npix = 1; npix <= 300; npix += 1) {
+		worst_case_data(pixels, npix);
+
+		maxelem = imcomp_calc_max_elem(PLIO_1, npix, 32, 0);
+		capacity = (size_t)maxelem / sizeof(short);
+
+		linelist = malloc(capacity * sizeof *linelist);
+		fail_if(linelist == NULL);
+
+		ret = pl_p2li(pixels, 1, linelist, capacity, npix);
+
+		/* it must succeed, and must have stayed inside the buffer */
+		fail_if(ret <= 0);
+		fail_if((size_t)ret > capacity);
+
+		free(linelist);
+	}
+}
+
+/*
+ * pl_p2li() must refuse to write beyond the end of the output buffer
+ */
+static void
+test_output_buffer_too_small(void)
+{
+	int pixels[16];
+	short linelist[128];
+	size_t dstlen;
+	int needed;
+
+	worst_case_data(pixels, 16);
+
+	needed = pl_p2li(pixels, 1, linelist, 128, 16);
+	fail_if(needed <= 7);
+
+	/* every buffer shorter than the line list has to be rejected */
+	for (dstlen = 0; dstlen < (size_t)needed; dstlen += 1) {
+		memset(linelist, 0x5a, sizeof linelist);
+
+		fail_if(pl_p2li(pixels, 1, linelist, dstlen, 16) >= 0);
+
+		/* nothing may have been written past the stated length */
+		for (size_t i = dstlen; i < 128; i += 1) {
+			fail_if(linelist[i] != (short)0x5a5a);
+		}
+	}
+
+	/* a buffer of exactly the right size still works */
+	fail_if(pl_p2li(pixels, 1, linelist, (size_t)needed, 16) != needed);
+}
+
 int
 main(void)
 {
@@ -183,6 +263,8 @@ main(void)
 	test_decode_more_than_encoded();
 	test_old_format_linelist();
 	test_opcode3_negative_delta();
+	test_fits_in_calculated_buffer();
+	test_output_buffer_too_small();
 
 	return 0;
 }


### PR DESCRIPTION
I used claude to review the issue reported #136 combined with a Valgrind scan to for out of bounds reads and instructed it to fix the bug. The actual bug was more widespread than initially reported. I think the addition of the `dstlen` to the function call is the right call here, despite changing a function signature. The actual fix is quite localized, most of the code in this MR are for test cases. Confirmed the fix passes valgrind.


## Problem

Compressing an image with PLIO writes past the end of the compressed tile
buffer. Reported as heasarc/cfitsio#136 for small images; valgrind on a 3x3
image:

```
Invalid write of size 2
   at pl_p2li (pliocomp.c:153)
   by imcomp_compress_tile (imcompress.c:1970)
   by fits_img_compress (imcompress.c:938)
 Address 0x4bda63e is 2 bytes after a block of size 12 alloc'd
   by imcomp_compress_tile (imcompress.c:1924)
```

Unpatched, `tests/test_imcompress` aborts with `free(): invalid next size (fast)`.

## Root cause

`imcomp_calc_max_elem()` falls through to `nx * sizeof(int)` for PLIO — 2 shorts
per pixel. `pl_p2li()` writes a 7 short header (`lldst[1..7]`, payload starts at
`op = 8`) plus, per pixel, up to 2 shorts to encode a value differing from the
previous one by more than 4095, plus 1 more for the run length: 3 shorts per
pixel. `pl_p2li()` also received no buffer length, so it could not notice.

**This is not only a small-image bug.** Measuring `pl_p2li()`'s output against
the allocated size for worst-case data (alternating 1 / 5000), every size from
1 to 300 pixels overflows:

```
npix=1    buffer=4 bytes (2 shorts) but line list needs 8 shorts   -> overflow by 12 bytes
npix=3    buffer=12 bytes (6 shorts) but line list needs 14 shorts -> overflow by 16 bytes
npix=300  buffer=1200 bytes (600 shorts) but needs 905 shorts      -> overflow by 610 bytes
300 of 300 sizes overflow the allocated buffer
```

So the fixes proposed in the issue thread are still too small: a 32 byte floor
only covers tiny tiles, and `(7 + 2*nx)` shorts is short by 1 short at npix=1
(needs 10, allows 9) and by 1 at npix=3 (needs 14, allows 13).

## Fix

- `imcomp_calc_max_elem()` gets a `PLIO_1` branch returning
  `(3 * nx + 7) * sizeof(short)`, the largest line list `pl_p2li()` can emit.
  Bound verified empirically over ~200k inputs (random full-range, alternating
  extremes, all-zero, all-same, and sizes spanning the 4095 run-length split):
  max payload is exactly 3.0 shorts/pixel, hit at npix=1.
- `pl_p2li()` takes a `size_t dstlen` (shorts available) and returns -1 rather
  than writing past the end — mirroring `pl_l2pi()`, which already takes
  `srclen`. `imcomp_compress_tile()` passes `clen / sizeof(short)` and already
  handles a negative return as `DATA_COMPRESSION_ERR`.

PLIO tile buffers are now 6 bytes per pixel instead of 4; the encoded output and
the file format are unchanged. `pl_p2li()` is internal (`fitsio2.h`), called only
from `imcompress.c` and the tests.


## Tests

- `tests/test_pliocomp.c`: `test_fits_in_calculated_buffer()` checks, for sizes
  1..300 of worst-case data, that the line list fits in exactly the buffer
  `imcomp_calc_max_elem()` asks for; `test_output_buffer_too_small()` checks that
  every under-sized `dstlen` is rejected with no write past the stated length,
  and that an exactly-sized buffer still succeeds. Existing call sites updated
  for the new signature.
- `tests/test_imcompress.c`: `test_plio_small_images()` round trips 1x1, 2x2,
  3x3, 5x4, 9x3 and 33x3 images through PLIO. This aborts (SIGABRT, heap
  corruption) on `develop` and passes with the fix.
