### PR TITLE
Fix heap overflow uncompressing tables with variable-length string columns (#134)

### DIFF
--- a/imcompress.c
+++ b/imcompress.c
@@ -8710,7 +8710,7 @@ int fits_uncompress_table(fitsfile *infptr, fitsfile *outfptr, int *status)
     LONGLONG nrows, rmajor_colwidth[999], rmajor_colstart[1000], cmajor_colstart[1000];
     LONGLONG cmajor_repeat[999], rmajor_repeat[999], cmajor_bytespan[999], kk;
     LONGLONG headstart, datastart = 0, dataend, rowsremain, *descript, *qdescript = 0;
-    LONGLONG rowstart, cvlalen, cvlastart, vlalen, vlastart;
+    LONGLONG rowstart, cvlalen, cvlastart, vlalen, vlastart, rowlen;
     long repeat, width, vla_repeat, vla_address, rowspertile, ntile;
     int  ncols, hdutype, inttype, anynull, tstatus, zctype[999], addspace = 0, *pdescript = 0;
     char *cptr, keyname[9], tform[40];
@@ -8848,16 +8848,20 @@ int fits_uncompress_table(fitsfile *infptr, fitsfile *outfptr, int *status)
         fits_binary_tform(tform, &inttype, &repeat, &width, status);
         coltype[ii] = inttype;
 
-	/* deal with special cases */
-	if (abs(coltype[ii]) == TBIT) { 
+	/* deal with special cases.  The datatype code is negative for a       */
+	/* variable length array, so these tests must not use abs(coltype):    */
+	/* the field of a variable length column holds descriptors, whatever   */
+	/* the datatype they point to.  Same tests as in fits_compress_table.  */
+	if (coltype[ii] == TBIT) {
 	        repeat = (repeat + 7) / 8 ;   /* convert from bits to bytes */
-	} else if (abs(coltype[ii]) == TSTRING) {
+	} else if (coltype[ii] == TSTRING) {
 	        width = 1;
 	} else if (coltype[ii] < 0) {  /* pointer to variable length array */
 	        if (colcode[ii] == 'P')
 	           width = 8;  /* this is a 'P' column */
 	        else
 	           width = 16;  /* this is a 'Q' not a 'P' column */
+	        repeat = 1;
 
                 addspace += 16; /* need space for a second set of Q pointers for this column */
 	}
@@ -8894,6 +8898,24 @@ int fits_uncompress_table(fitsfile *infptr, fitsfile *outfptr, int *status)
 
     /* rescan header keywords to reset internal table structure parameters */
     fits_set_hdustruc(outfptr, status);
+
+    if (*status > 0)
+        return(*status);
+
+    /* The buffers below are sized from ZNAXIS1, but the offset of each column */
+    /* within them is computed from the ZFORMn keywords.  If those disagree    */
+    /* then the columns do not fit in the buffers, so reject the table rather  */
+    /* than write outside of them.                                             */
+    rowlen = 0;
+    for (ii = 0; ii < ncols; ii++)
+        rowlen += rmajor_colwidth[ii];
+
+    if (rowlen != (LONGLONG) naxis1) {
+        ffpmsg("Sum of the ZFORMn column widths does not equal ZNAXIS1");
+        ffpmsg(" (fits_uncompress_table)");
+        *status = DATA_DECOMPRESSION_ERR;
+        return(*status);
+    }
 
     /* ================================================================================== */
     /* allocate memory for the transposed and untransposed tile of the table */
@@ -8981,7 +9003,7 @@ int fits_uncompress_table(fitsfile *infptr, fitsfile *outfptr, int *status)
                      ffswap2((short *) cptr, fullsize / 2); 
 #endif
 	          } else { /* gunzip the data into the correct location */
-	             uncompress2mem_from_mem(ptr, vla_repeat, &cptr, &fullsize, realloc, &dlen, status);        
+	             uncompress2mem_from_mem(ptr, vla_repeat, &cptr, &fullsize, NULL, &dlen, status);        
 	          }
 	          break;
 
@@ -8994,7 +9016,7 @@ int fits_uncompress_table(fitsfile *infptr, fitsfile *outfptr, int *status)
                       ffswap4((int *) cptr,  fullsize / 4); 
 #endif
 	          } else { /* gunzip the data into the correct location */
-	             uncompress2mem_from_mem(ptr, vla_repeat, &cptr, &fullsize, realloc, &dlen, status);        
+	             uncompress2mem_from_mem(ptr, vla_repeat, &cptr, &fullsize, NULL, &dlen, status);        
 	          }
 	          break;
 
@@ -9004,7 +9026,7 @@ int fits_uncompress_table(fitsfile *infptr, fitsfile *outfptr, int *status)
    	              dlen = fits_rdecomp_byte ((unsigned char *) ptr, vla_repeat, (unsigned char *)cptr, 
 		        fullsize, 32);
 	          } else { /* gunzip the data into the correct location */
-	             uncompress2mem_from_mem(ptr, vla_repeat, &cptr, &fullsize, realloc, &dlen, status);        
+	             uncompress2mem_from_mem(ptr, vla_repeat, &cptr, &fullsize, NULL, &dlen, status);        
 	          }
 	          break;
 
@@ -9012,11 +9034,22 @@ int fits_uncompress_table(fitsfile *infptr, fitsfile *outfptr, int *status)
 		  /* all variable length array columns are included in this case */
 	          /* gunzip the data into the correct location in the full table buffer */
 	          uncompress2mem_from_mem(ptr, vla_repeat,
-	              &cptr,  &fullsize, realloc, &dlen, status);              
+	              &cptr,  &fullsize, NULL, &dlen, status);              
 
 	        } /* end of switch block */
 
 	        free(ptr);
+
+	        /* The uncompressed bytes must fit exactly in the space that was */
+	        /* reserved for this column;  cptr points into the middle of     */
+	        /* cm_buffer, so it cannot be reallocated to make more room.     */
+	        /* A stream that expands beyond the reserved space means the     */
+	        /* compressed table is corrupt.                                  */
+	        if (*status > 0) {
+	            ffpmsg("Error uncompressing a column of the compressed table");
+	            free(rm_buffer);  free(cm_buffer);
+	            return(*status);
+	        }
 	  }  /* end of rmajor_repeat > 0 */
       }  /* end of loop over columns */
       

--- a/tests/test_imcompress.c
+++ b/tests/test_imcompress.c
@@ -11,6 +11,7 @@
 
 #define test_path "test_imcompress.fits"
 #define test_path2 "test_imcompress2.fits"
+#define test_path3 "test_imcompress3.fits"
 
 /*
  * Helper to create a simple test image
@@ -557,6 +558,152 @@ test_dither_seed(void)
 	fail_if(status != 0);
 }
 
+/*
+ * The variable-length string in a given row of the table built below
+ */
+static void
+vla_string(char *buf, size_t size, long row)
+{
+	int k, n = (int)(row % 15);
+	int p = snprintf(buf, size, "obj_");
+
+	for (k = 0; k < n; k += 1) {
+		buf[p] = 'x';
+		p += 1;
+	}
+	buf[p] = '\0';
+}
+
+/*
+ * Round trip a table containing variable-length array columns through
+ * fits_compress_table / fits_uncompress_table (what "fpack -table" does).
+ *
+ * A variable-length *string* column ('1PA') used to be sized as if its field
+ * held one byte per row rather than an 8 byte 'P' descriptor, so
+ * fits_uncompress_table reserved too little room for the column and gunzipped
+ * past the end of its buffer, corrupting the heap - see heasarc/cfitsio
+ * issue #134.
+ */
+static void
+test_compress_table_vla(void)
+{
+	fitsfile *in, *out, *back;
+	int status = 0, anynull, ztable = 0;
+	long nrows = 600, nback = 0, i;
+	char *ttype[] = { "vstr", "vflt", "vint", "fixstr" };
+	char *tform[] = { "1PA", "1PE", "1PJ", "8A" };
+	char *tunit[] = { "", "", "", "" };
+
+	/* Build the uncompressed table.  It has to be larger than 5760 bytes,
+	   otherwise fits_compress_table just copies it verbatim. */
+	fits_create_file(&in, "!" test_path, &status);
+	fail_if(status != 0);
+	fits_create_tbl(in, BINARY_TBL, 0, 4, ttype, tform, tunit, "DATA",
+		&status);
+	fail_if(status != 0);
+
+	for (i = 0; i < nrows; i += 1) {
+		char str[64], fixed[16], *cell[1];
+		float f[16];
+		int jv[16];
+		int k, n = 1 + (int)(i % 12);
+
+		vla_string(str, sizeof str, i);
+		cell[0] = str;
+		fits_write_col(in, TSTRING, 1, i + 1, 1, 1, cell, &status);
+
+		for (k = 0; k < n; k += 1) {
+			f[k] = (float)(i + k) * 1.5f;
+			jv[k] = (int)(i * 100 + k);
+		}
+		fits_write_col(in, TFLOAT, 2, i + 1, 1, n, f, &status);
+		fits_write_col(in, TINT, 3, i + 1, 1, n, jv, &status);
+
+		snprintf(fixed, sizeof fixed, "row%04ld", i);
+		cell[0] = fixed;
+		fits_write_col(in, TSTRING, 4, i + 1, 1, 1, cell, &status);
+	}
+	fail_if(status != 0);
+	fits_close_file(in, &status);
+	fail_if(status != 0);
+
+	/* Compress it */
+	fits_open_file(&in, test_path, READONLY, &status);
+	fail_if(status != 0);
+	fits_movabs_hdu(in, 2, NULL, &status);
+	fail_if(status != 0);
+	fits_create_file(&out, "!" test_path2, &status);
+	fail_if(status != 0);
+	fits_compress_table(in, out, &status);
+	fail_if(status != 0);
+	fits_close_file(in, &status);
+	fits_close_file(out, &status);
+	fail_if(status != 0);
+
+	/* The table must really have been compressed, or this test would
+	   silently exercise nothing */
+	fits_open_file(&out, test_path2, READONLY, &status);
+	fail_if(status != 0);
+	fits_movabs_hdu(out, 2, NULL, &status);
+	fail_if(status != 0);
+	fits_read_key(out, TLOGICAL, "ZTABLE", &ztable, NULL, &status);
+	fail_if(status != 0);
+	fail_if(!ztable);
+
+	/* Uncompress it again */
+	fits_create_file(&back, "!" test_path3, &status);
+	fail_if(status != 0);
+	fits_uncompress_table(out, back, &status);
+	fail_if(status != 0);
+	fits_close_file(out, &status);
+	fits_close_file(back, &status);
+	fail_if(status != 0);
+
+	/* Every value must have survived the round trip */
+	fits_open_file(&back, test_path3, READONLY, &status);
+	fail_if(status != 0);
+	fits_movabs_hdu(back, 2, NULL, &status);
+	fail_if(status != 0);
+	fits_get_num_rows(back, &nback, &status);
+	fail_if(status != 0);
+	fail_if(nback != nrows);
+
+	for (i = 0; i < nrows; i += 1) {
+		char expect[64], got[64], *cell[1];
+		float f[16];
+		int jv[16];
+		long repeat, offset;
+		int k, n = 1 + (int)(i % 12);
+
+		cell[0] = got;
+
+		vla_string(expect, sizeof expect, i);
+		fits_read_col(back, TSTRING, 1, i + 1, 1, 1, "", cell,
+			&anynull, &status);
+		fail_if(strcmp(got, expect) != 0);
+
+		fits_read_descript(back, 2, i + 1, &repeat, &offset, &status);
+		fail_if(repeat != n);
+		fits_read_col(back, TFLOAT, 2, i + 1, 1, n, NULL, f, &anynull,
+			&status);
+		fits_read_col(back, TINT, 3, i + 1, 1, n, NULL, jv, &anynull,
+			&status);
+		for (k = 0; k < n; k += 1) {
+			fail_if(f[k] != (float)(i + k) * 1.5f);
+			fail_if(jv[k] != (int)(i * 100 + k));
+		}
+
+		snprintf(expect, sizeof expect, "row%04ld", i);
+		fits_read_col(back, TSTRING, 4, i + 1, 1, 1, "", cell,
+			&anynull, &status);
+		fail_if(strcmp(got, expect) != 0);
+	}
+	fail_if(status != 0);
+
+	fits_close_file(back, &status);
+	fail_if(status != 0);
+}
+
 int
 main(void)
 {
@@ -570,10 +717,12 @@ main(void)
 	test_hcompress_compress();
 	test_is_compressed_uncompressed();
 	test_compress_byte_image();
+	test_compress_table_vla();
 	test_dither_seed();
 
 	remove(test_path);
 	remove(test_path2);
+	remove(test_path3);
 
 	return 0;
 }

--- a/tests/tests.am
+++ b/tests/tests.am
@@ -147,6 +147,7 @@ CLEANFILES += \
 	test_histo_out.fits \
 	test_imcompress.fits \
 	test_imcompress2.fits \
+	test_imcompress3.fits \
 	test_iraffits.imh \
 	test_iraffits.pix \
 	test_modkey.fits \


### PR DESCRIPTION
Fixes #134: `funpack` aborts with `realloc(): invalid next size` on its own
`fpack -table` output when the table has a `1PA` column.

### Cause

`fits_uncompress_table` sizes each column's slice of the decompression buffer
from `ZFORMn`, but compares the datatype code with `abs()`:

```c
if (abs(coltype[ii]) == TBIT) {
} else if (abs(coltype[ii]) == TSTRING) {
        width = 1;
} else if (coltype[ii] < 0) {    /* variable length array - never reached for 1PA */
```

`ffbnfm` returns a negative code for a variable-length array, so `1PA` has
`coltype = -TSTRING` and took the string branch: 1 byte per row instead of an
8-byte `P` descriptor, and the extra 16 bytes per row for the second descriptor
set were never added to `cm_size`. The gunzipped blob needs
`(8 + 16) * rowspertile` bytes and got `1 * rowspertile`. `fits_compress_table`
compares without `abs()`, so the compressed file is fine — only reading it back
overruns the buffer. The same comparisons also mis-size variable-length bit
columns.

Nothing catches the overrun because the destination is an interior pointer of
`cm_buffer` and `uncompress2mem_from_mem` is given `realloc`, which then
reallocs a pointer that is not the start of a heap block.

### Change

- Drop the two `abs()` calls, so the tests match `fits_compress_table`.
- Pass `NULL` instead of `realloc` for the four in-place gunzip calls, so an
  over-long stream fails with `DATA_DECOMPRESSION_ERR` instead of reallocating
  an interior pointer, and bail out of the tile loop when it does.
- Reject the table if the `ZFORMn` widths do not sum to `ZNAXIS1`; the buffers
  are sized from one and indexed with the other, so this would have caught the
  bug above as a clean error.

### Tests

New `test_compress_table_vla()` in `tests/test_imcompress.c` (this fork's unit
suite) round-trips a 600-row table with `1PA`, `1PE`, `1PJ` and `8A` columns
through `fits_compress_table`/`fits_uncompress_table` and checks every value.
It aborts on `develop` and passes with this change.

Also verified: `testprog` output and `.fit` unchanged; the issue's reproducer
now funpacks with all 3000 strings intact; `fpack -table`/`funpack` round trip
of `testprog.fit` OK; valgrind and ASan clean on the new test and on `funpack`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)