### PR TITLE
Fix memory-safety defects in the unit test suite

### DIFF
--- a/tests/test_drvrsmem.c
+++ b/tests/test_drvrsmem.c
@@ -189,6 +189,8 @@ test_cleanup_locked_segment(void)
 	call_02(ffinit, &f, "shmem://h2");
 	call_04(ffphps, f, BYTE_IMG, 1, naxes);
 	smem_shutdown();
+	/* Not ffclos: it would flush into the now-detached segment. */
+	free(f);
 }
 
 
@@ -207,6 +209,7 @@ test_cleanup_with_debug(void)
 	call_02(ffinit, &f, "shmem://h5");
 	call_04(ffphps, f, BYTE_IMG, 1, naxes);
 	fail_if(smem_shutdown());
+	free(f);
 }
 
 

--- a/tests/test_getcold.c
+++ b/tests/test_getcold.c
@@ -211,7 +211,7 @@ test_read_subsection_with_increment(void)
 	int status = 0;
 	long naxes[] = { 6, 6 };
 	double data[36];
-	double result[4];
+	double result[9];  /* 3 x 3 pixels are selected by the increment. */
 	long fpixel[] = { 1, 1 };
 	long lpixel[] = { 5, 5 };
 	long inc[] = { 2, 2 };  /* Skip every other pixel. */
@@ -230,11 +230,15 @@ test_read_subsection_with_increment(void)
 	call_03(ffopen, &f, test_path, READONLY);
 	call_10(ffgsvd, f, 1, 2, naxes, fpixel, lpixel, inc, 0.0, result, &anynull);
 	/* With increment 2, reading [1,3,5] x [1,3,5]. */
-	/* Indices: (0,0)=0, (2,0)=2, (4,0)=4, (0,2)=12, ... */
 	fail_if(result[0] != 0.0);   /* (1,1) -> index 0. */
 	fail_if(result[1] != 2.0);   /* (3,1) -> index 2. */
 	fail_if(result[2] != 4.0);   /* (5,1) -> index 4. */
 	fail_if(result[3] != 12.0);  /* (1,3) -> index 12. */
+	fail_if(result[4] != 14.0);  /* (3,3) -> index 14. */
+	fail_if(result[5] != 16.0);  /* (5,3) -> index 16. */
+	fail_if(result[6] != 24.0);  /* (1,5) -> index 24. */
+	fail_if(result[7] != 26.0);  /* (3,5) -> index 26. */
+	fail_if(result[8] != 28.0);  /* (5,5) -> index 28. */
 	call_01(ffclos, f);
 }
 

--- a/tests/test_getcole.c
+++ b/tests/test_getcole.c
@@ -211,7 +211,7 @@ test_read_subsection_with_increment(void)
 	int status = 0;
 	long naxes[] = { 6, 6 };
 	float data[36];
-	float result[4];
+	float result[9];  /* 3 x 3 pixels are selected by the increment. */
 	long fpixel[] = { 1, 1 };
 	long lpixel[] = { 5, 5 };
 	long inc[] = { 2, 2 };  /* Skip every other pixel. */
@@ -234,6 +234,11 @@ test_read_subsection_with_increment(void)
 	fail_if(result[1] != 2.0f);   /* (3,1) -> index 2. */
 	fail_if(result[2] != 4.0f);   /* (5,1) -> index 4. */
 	fail_if(result[3] != 12.0f);  /* (1,3) -> index 12. */
+	fail_if(result[4] != 14.0f);  /* (3,3) -> index 14. */
+	fail_if(result[5] != 16.0f);  /* (5,3) -> index 16. */
+	fail_if(result[6] != 24.0f);  /* (1,5) -> index 24. */
+	fail_if(result[7] != 26.0f);  /* (3,5) -> index 26. */
+	fail_if(result[8] != 28.0f);  /* (5,5) -> index 28. */
 	call_01(ffclos, f);
 }
 

--- a/tests/test_putcolb.c
+++ b/tests/test_putcolb.c
@@ -1349,7 +1349,10 @@ test_ffpextn(void)
 	fitsfile *f;
 	int status = 0;
 	long naxes[] = { 10 };
-	unsigned char data[] = { 0xAA, 0xBB, 0xCC, 0xDD };
+	/* One element per pixel of the naxes[0] == 10 image. */
+	unsigned char data[] = {
+		0xAA, 0xBB, 0xCC, 0xDD, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66
+	};
 	unsigned char result[4];
 	int anynull;
 

--- a/tests/test_region.c
+++ b/tests/test_region.c
@@ -906,6 +906,9 @@ test_fk5_format(void)
 	fits_read_ascii_region(region_file, NULL, &rgn, &status);
 	/* This should succeed but with 0 shapes or fail for empty */
 	/* Behavior depends on implementation */
+	if (rgn) {
+		fits_free_region(rgn);
+	}
 }
 
 static void
@@ -917,6 +920,9 @@ test_fk4_format(void)
 	/* FK4 format line alone */
 	write_region_file("fk4\n");
 	fits_read_ascii_region(region_file, NULL, &rgn, &status);
+	if (rgn) {
+		fits_free_region(rgn);
+	}
 }
 
 static void
@@ -928,6 +934,9 @@ test_icrs_format(void)
 	/* ICRS format line alone */
 	write_region_file("icrs\n");
 	fits_read_ascii_region(region_file, NULL, &rgn, &status);
+	if (rgn) {
+		fits_free_region(rgn);
+	}
 }
 
 static void


### PR DESCRIPTION
Ran libsanitizer ASan and LSan over the test suite and found a couple of issues.