### PR TITLE
Add support for x32 ABI on x86‑64 (ILP32)

### DIFF
--- a/fitsio2.h
+++ b/fitsio2.h
@@ -98,6 +98,11 @@ extern int Fitsio_Pthread_Status;
 #define BYTESWAPPED FALSE
 #define LONGSIZE 32
 
+#elif defined(__x86_64__) && defined(__ILP32__)
+		/* 64-bit PC with 32-bit integer/long/pointers (ILP32) */
+#define BYTESWAPPED TRUE
+#define LONGSIZE 32
+
 #elif defined(__ia64__)  || defined(__x86_64__) || defined(__AARCH64EL__)
                   /*  Intel itanium 64-bit PC, or AMD opteron 64-bit PC */
 #define BYTESWAPPED TRUE


### PR DESCRIPTION
On x86-64 hardware, the x32 ABI uses 32-bit integer, long and pointers, (hence the name ILP32), while having access to all the new x86-64 registers. It can be selected with GCC using -mx32.

cfitsio works relatively well on such a configuration, but one of the tests added as part of the 4.7.0 release fails:

| FAIL: tests/test_getcolk
| ========================
|
| tests/test_getcolk.c test failed at line 495: status != NUM_OVERFLOW | FAIL tests/test_getcolk (exit status: 1)

I have tracked that to the wrong value of LONGSIZE in that case, it should be 64 instead of 32. This patch therefore adds a special case to define LONGSIZE for this ABI.