### PR TITLE
Fix warning due to ISO C23 const return types

### DIFF
--- a/modkey.c
+++ b/modkey.c
@@ -1192,7 +1192,8 @@ int ffikls( fitsfile *fptr,           /* I - FITS file pointer        */
 {
     char valstring[FLEN_VALUE];
     char card[FLEN_CARD], tmpkeyname[FLEN_CARD];
-    char tstring[FLEN_VALUE], *cptr;
+    char tstring[FLEN_VALUE];
+    const char *cptr;
     int next, remain, vlen, nquote, nchar, namelen, contin, tstatus = -1;
 
     if (*status > 0)           /* inherit input status value if > 0 */


### PR DESCRIPTION
Starting with GNU libc 2.43, when using a compiler defaulting to ISO C23 or newer (e.g. GCC 15 or 16), strchr() and other string functions now return a pointer to a const-qualified type when the input argument is a pointer to a const-qualified type.

This causes the following warning when building cfitsio with -Wall:

modkey.c: In function 'ffikls':
modkey.c:1207:10: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 1207 |     cptr = strchr(value, '\'');   /* search for quote character */
      |          ^

Fix that by declaring cptr as const char *.